### PR TITLE
Add costmap downsampler - fixes SteveMacenski/navigation2#4

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -254,6 +254,8 @@ planner_server:
 
     GridBased:
       tolerance: 0.5                    # tolerance for planning if unable to reach exact pose, in meters
+      downsample_costmap: true          # whether or not to downsample the map to the specified resolution
+      costmap_resolution: 0.3           # target resolution for the planner grid, in meters
       allow_unknown: false              # allow traveling in unknown space
       travel_cost_scale: 0.8            # [0,1] metric for how much you value staying out of higher-cost spaces (higher more adverse)
       max_iterations: -1                # maximum total iterations to search for before returning
@@ -270,8 +272,8 @@ planner_server:
           w_curve: 30.0 #3.0 # range 0 - 50
           w_dist: 0.0 #300 w/0 cost
           w_smooth: 15000.0 #15000
-          w_cost: 0.025
-          max_curve: 2.0         # translates to |delta angle| / |delta distance|, where distance is ~2x costmap resolution
+          w_cost: 2.5
+          max_curve: 2.0        # translates to |delta angle| / |delta distance|, where distance is ~2x costmap resolution
           cost_scaling_factor: 1.0 # this should match the inflation layer's parameter
           # 7.8 in 5cm resolution (45 deg / 10cm)
           # 4.0 in 10cm resolution (45 deg / 20 cm)

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -254,8 +254,8 @@ planner_server:
 
     GridBased:
       tolerance: 0.5                    # tolerance for planning if unable to reach exact pose, in meters
-      downsample_costmap: true          # whether or not to downsample the map to the specified resolution
-      costmap_resolution: 0.3           # target resolution for the planner grid, in meters
+      downsample_costmap: false         # whether or not to downsample the map to the specified resolution
+      downsampling_factor: 3            # multiplier for the resolution of the costmap layer
       allow_unknown: false              # allow traveling in unknown space
       travel_cost_scale: 0.8            # [0,1] metric for how much you value staying out of higher-cost spaces (higher more adverse)
       max_iterations: -1                # maximum total iterations to search for before returning
@@ -272,7 +272,7 @@ planner_server:
           w_curve: 30.0 #3.0 # range 0 - 50
           w_dist: 0.0 #300 w/0 cost
           w_smooth: 15000.0 #15000
-          w_cost: 2.5
+          w_cost: 0.025         # Use higher value when using the costmap downsampler (e.g. use 2.5 for downsampling_factor = 3)
           max_curve: 2.0        # translates to |delta angle| / |delta distance|, where distance is ~2x costmap resolution
           cost_scaling_factor: 1.0 # this should match the inflation layer's parameter
           # 7.8 in 5cm resolution (45 deg / 10cm)

--- a/nav2_bringup/bringup/rviz/nav2_default_view.rviz
+++ b/nav2_bringup/bringup/rviz/nav2_default_view.rviz
@@ -249,6 +249,20 @@ Visualization Manager:
             Value: /global_costmap/costmap
           Use Timestamp: false
           Value: true
+        - Alpha: 0.3
+          Class: rviz_default_plugins/Map
+          Color Scheme: costmap
+          Draw Behind: false
+          Enabled: true
+          Name: Downsampled Costmap
+          Topic:
+            Depth: 1
+            Durability Policy: Transient Local
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /downsampled_costmap
+          Use Timestamp: false
+          Value: true
         - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -34,7 +34,8 @@ public:
    */
   explicit CostmapDownsampler()
   : _costmap(nullptr),
-    _downsampled_costmap(nullptr)
+    _downsampled_costmap(nullptr),
+    _downsampled_costmap_pub(nullptr)
   {
   }
 
@@ -54,10 +55,10 @@ public:
    * @param downsampling_factor Multiplier for the costmap sresolution
    */
    void initialize(
-    nav2_util::LifecycleNode::SharedPtr node,
-    std::string global_frame,
-    std::string topic_name,
-    nav2_costmap_2d::Costmap2D * costmap,
+    const nav2_util::LifecycleNode::SharedPtr & node,
+    const std::string & global_frame,
+    const std::string & topic_name,
+    nav2_costmap_2d::Costmap2D * const costmap,
     const unsigned int & downsampling_factor)
   {
     _node = node;

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -31,11 +31,13 @@ class CostmapDownsampler
 public:
   /**
    * @brief A constructor for CostmapDownsampler
+   * @param node Lifecycle node pointer
    */
-  explicit CostmapDownsampler()
+  explicit CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node)
   : _costmap(nullptr),
     _downsampled_costmap(nullptr),
-    _downsampled_costmap_pub(nullptr)
+    _downsampled_costmap_pub(nullptr),
+    _node(node)
   {
   }
 
@@ -48,20 +50,17 @@ public:
 
   /**
    * @brief Initialize the downsampled costmap object and the ROS publisher
-   * @param node Lifecycle node pointer
    * @param global_frame The ID of the global frame used by the costmap
    * @param topic_name The name of the topic to publish the downsampled costmap
    * @param costmap The costmap we want to downsample
-   * @param downsampling_factor Multiplier for the costmap sresolution
+   * @param downsampling_factor Multiplier for the costmap resolution
    */
    void initialize(
-    const nav2_util::LifecycleNode::SharedPtr & node,
     const std::string & global_frame,
     const std::string & topic_name,
     nav2_costmap_2d::Costmap2D * const costmap,
     const unsigned int & downsampling_factor)
   {
-    _node = node;
     _topic_name = topic_name;
     _costmap = costmap;
     _downsampling_factor = downsampling_factor;
@@ -91,16 +90,19 @@ public:
 
   /**
    * @brief Downsample the given costmap by the downsampling factor, and publish the downsampled costmap
+   * @param downsampling_factor Multiplier for the costmap resolution
    * @return A ptr to the downsampled costmap
    */
-  nav2_costmap_2d::Costmap2D * downsample()
+  nav2_costmap_2d::Costmap2D * downsample(const unsigned int & downsampling_factor)
   {
     unsigned int new_mx, new_my;
+    _downsampling_factor = downsampling_factor;
     updateCostmapSize();
 
     // Adjust costmap size if needed
     if (_downsampled_costmap->getSizeInCellsX() != _downsampled_size_x ||
-      _downsampled_costmap->getSizeInCellsY() != _downsampled_size_y) {
+      _downsampled_costmap->getSizeInCellsY() != _downsampled_size_y ||
+      _downsampled_costmap->getResolution() != _downsampled_resolution) {
       resizeCostmap();
     }
 

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -162,12 +162,12 @@ private:
     for (int i = 0; i < _downsampling_factor; ++i) {
       mx = x_offset + i;
       if (mx >= _size_x) {
-        break;
+        continue;
       }
       for (int j = 0; j < _downsampling_factor; ++j) {
         my = y_offset + j;
         if (my >= _size_y) {
-          break;
+          continue;
         }
         cost = std::max(cost, _costmap->getCost(mx, my));
       }

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -95,7 +95,6 @@ public:
    */
   nav2_costmap_2d::Costmap2D * downsample(const unsigned int & downsampling_factor)
   {
-    unsigned int new_mx, new_my;
     _downsampling_factor = downsampling_factor;
     updateCostmapSize();
 
@@ -107,10 +106,10 @@ public:
     }
 
     // Assign costs
-    for (int i = 0; i < _downsampled_size_x * _downsampled_size_y; ++i) {
-      new_mx = i % _downsampled_size_x;
-      new_my = i / _downsampled_size_x;
-      setCostOfCell(new_mx, new_my);
+    for (int i = 0; i < _downsampled_size_x; ++i) {
+      for (int j = 0; j < _downsampled_size_y; ++j) {
+        setCostOfCell(i, j);
+      }
     }
 
     if (_node->count_subscribers(_topic_name) > 0) {
@@ -160,11 +159,20 @@ private:
     unsigned int x_offset = new_mx * _downsampling_factor;
     unsigned int y_offset = new_my * _downsampling_factor;
 
-    for(int j = 0; j < _downsampling_factor * _downsampling_factor; ++j) {
-      mx = std::min(x_offset + j % _downsampling_factor, _size_x - 1);
-      my = std::min(y_offset + j / _downsampling_factor, _size_y - 1);
-      cost = std::max(cost, _costmap->getCost(mx, my));
+    for (int i = 0; i < _downsampling_factor; ++i) {
+      mx = x_offset + i;
+      if (mx >= _size_x) {
+        continue;
+      }
+      for (int j = 0; j < _downsampling_factor; ++j) {
+        my = y_offset + j;
+        if (my >= _size_y) {
+          continue;
+        }
+        cost = std::max(cost, _costmap->getCost(mx, my));
+      }
     }
+
     _downsampled_costmap->setCost(new_mx, new_my, cost);
   }
 

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -162,12 +162,12 @@ private:
     for (int i = 0; i < _downsampling_factor; ++i) {
       mx = x_offset + i;
       if (mx >= _size_x) {
-        continue;
+        break;
       }
       for (int j = 0; j < _downsampling_factor; ++j) {
         my = y_offset + j;
         if (my >= _size_y) {
-          continue;
+          break;
         }
         cost = std::max(cost, _costmap->getCost(mx, my));
       }

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2020, Carlos Luis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#ifndef SMAC_PLANNER__DOWNSAMPLER_HPP_
+#define SMAC_PLANNER__DOWNSAMPLER_HPP_
+
+#include <algorithm>
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
+#include "smac_planner/constants.hpp"
+
+namespace smac_planner
+{
+
+/**
+ * @class smac_planner::CostmapDownsampler
+ * @brief A costmap downsampler for more efficient path planning
+ */
+class CostmapDownsampler
+{
+public:
+  /**
+   * @brief A constructor for CostmapDownsampler
+   */
+  explicit CostmapDownsampler()
+  : _sampling_factor(0)
+  {
+  }
+
+  /**
+   * @brief A destructor for CostmapDownsampler
+   */
+  ~CostmapDownsampler()
+  {
+  }
+
+  /**
+   * @brief Downsample the given costmap to the closest approximation of the target resolution
+   * @param original_costmap The costmap we want to downsample
+   * @param target_resolution The desired size of a cell in the new costmap, in meters
+   * @return A pointer to the newly created downsampled costmap
+   * Note: despite returning a pointer, this class keeps ownership of the resource it created.
+   */
+  nav2_costmap_2d::Costmap2D * downsample(
+    nav2_costmap_2d::Costmap2D * original_costmap,
+    const float & target_resolution)
+  {
+    _original_size_x = original_costmap->getSizeInCellsX();
+    _original_size_y = original_costmap->getSizeInCellsY();
+    _original_costmap = original_costmap;
+    _sampling_factor = round(target_resolution / original_costmap->getResolution());
+    float rounded_resolution = _sampling_factor * original_costmap->getResolution();
+    unsigned int map_cells_size_x = ceil(static_cast<float>(original_costmap->getSizeInCellsX()) / _sampling_factor);
+    unsigned int map_cells_size_y = ceil(static_cast<float>(original_costmap->getSizeInCellsY()) / _sampling_factor);
+
+    _downsampled_costmap = std::make_unique<nav2_costmap_2d::Costmap2D>
+      (map_cells_size_x, map_cells_size_y, rounded_resolution,
+       original_costmap->getOriginX(), original_costmap->getOriginY(), UNKNOWN);
+
+    setCosts();
+    return _downsampled_costmap.get();
+  }
+
+private:
+  /**
+   * @brief Iterate through every cell of the downsampled costmap and assign a cost to it
+   */
+  void setCosts()
+  {
+    unsigned int new_size_x = _downsampled_costmap->getSizeInCellsX();
+    unsigned int new_size_y = _downsampled_costmap->getSizeInCellsY();
+
+    for (int i = 0; i < new_size_x * new_size_y; ++i) {
+      int new_mx = i % new_size_x;
+      int new_my = i / new_size_x;
+      setCostOfCell(new_mx, new_my);
+    }
+  }
+
+  /**
+   * @brief Explore all subcells of the original costmap and assign the max cost to the new (downsampled) cell
+   * @param new_mx The X-coordinate of the cell in the new costmap
+   * @param new_my The Y-coordinate of the cell in the new costmap
+   */
+  void setCostOfCell(
+    const unsigned int & new_mx, const unsigned int & new_my)
+  {
+    unsigned char cost = 0;
+    for(int j = 0; j < _sampling_factor * _sampling_factor; ++j)
+    {
+      unsigned int mx = std::min(new_mx * _sampling_factor + j % _sampling_factor, _original_size_x - 1);
+      unsigned int my = std::min(new_my * _sampling_factor + j / _sampling_factor, _original_size_y - 1);
+      cost = std::max(cost, _original_costmap->getCost(mx, my));
+    }
+    _downsampled_costmap->setCost(new_mx, new_my, cost);
+  }
+
+  unsigned int _sampling_factor;
+  unsigned int _original_size_x;
+  unsigned int _original_size_y;
+  std::unique_ptr<nav2_costmap_2d::Costmap2D> _downsampled_costmap;
+  nav2_costmap_2d::Costmap2D * _original_costmap;
+};
+
+}  // namespace smac_planner
+
+#endif // SMAC_PLANNER__DOWNSAMPLER_HPP_

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -95,8 +95,6 @@ protected:
   std::unique_ptr<Smoother> _smoother;
   std::unique_ptr<Upsampler> _upsampler;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
-  std::unique_ptr<nav2_costmap_2d::Costmap2DPublisher> _costmap_pub;
-  std::shared_ptr<nav2_costmap_2d::Costmap2D> _downsampled_costmap;
   nav2_util::LifecycleNode::SharedPtr _node;
   nav2_costmap_2d::Costmap2D * _costmap;
   std::string _global_frame, _name;
@@ -110,7 +108,6 @@ protected:
   SmootherParams _smoother_params;
   OptimizerParams _optimizer_params;
   int _upsampling_ratio;
-  std::string _costmap_topic_name;
 };
 
 }  // namespace smac_planner

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -91,9 +91,6 @@ public:
   void removeHook(std::vector<Eigen::Vector2d> & path);
 
 protected:
-
-  inline bool shouldDownsample();
-
   std::unique_ptr<AStarAlgorithm<Node>> _a_star;
   std::unique_ptr<Smoother> _smoother;
   std::unique_ptr<Upsampler> _upsampler;
@@ -113,6 +110,7 @@ protected:
   SmootherParams _smoother_params;
   OptimizerParams _optimizer_params;
   int _upsampling_ratio;
+  std::string _costmap_topic_name;
 };
 
 }  // namespace smac_planner

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -92,46 +92,27 @@ public:
 
 protected:
 
-  /**
-   * @brief Initialize the costmap to be used for planning.
-   * We either use the original costmap or downsample it for more efficient graph search.
-   */
-  void initCostmap();
-
-  /**
-   * @brief Create an occupancy grid to be published and visualized in rviz.
-   * The code was borrowed from costmap_2d_publisher.cpp
-   * @param costmap The costmap to be converted into occupancy grid
-   */
-  void createOccupancyGridFromCostmap(const nav2_costmap_2d::Costmap2D * costmap);
-
-  /**
-   * @brief Helper method to create conversion table between values of a costmap and an occupancy grid.
-   * The code was borrowed from costmap_2d_publisher.cpp
-   */
-  void setCostTranslationTable();
+  inline bool shouldDownsample();
 
   std::unique_ptr<AStarAlgorithm<Node>> _a_star;
   std::unique_ptr<Smoother> _smoother;
   std::unique_ptr<Upsampler> _upsampler;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
-  std::unique_ptr<nav_msgs::msg::OccupancyGrid> _grid;
+  std::unique_ptr<nav2_costmap_2d::Costmap2DPublisher> _costmap_pub;
+  std::shared_ptr<nav2_costmap_2d::Costmap2D> _downsampled_costmap;
   nav2_util::LifecycleNode::SharedPtr _node;
-  nav2_costmap_2d::Costmap2D * _original_costmap;
   nav2_costmap_2d::Costmap2D * _costmap;
   std::string _global_frame, _name;
   float _tolerance;
-  float _resolution;
+  int _downsampling_factor;
   bool _downsample_costmap;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug1_pub;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug2_pub;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug3_pub;
-  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::OccupancyGrid>::SharedPtr _downsampled_costmap_pub;
   SmootherParams _smoother_params;
   OptimizerParams _optimizer_params;
   int _upsampling_ratio;
-  char * _cost_translation_table;
 };
 
 }  // namespace smac_planner

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -196,8 +196,8 @@ void SmacPlanner::configure(
 
   if (_downsample_costmap && _downsampling_factor > 1) {
     std::string topic_name = "downsampled_costmap";
-    _costmap_downsampler = std::make_unique<CostmapDownsampler>();
-    _costmap_downsampler->initialize(_node, _global_frame, topic_name, _costmap, _downsampling_factor);
+    _costmap_downsampler = std::make_unique<CostmapDownsampler>(_node);
+    _costmap_downsampler->initialize(_global_frame, topic_name, _costmap, _downsampling_factor);
   }
 
   _raw_plan_publisher = _node->create_publisher<nav_msgs::msg::Path>("unsmoothed_plan", 1);
@@ -260,11 +260,9 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
 #endif
 
   // Choose which costmap to use for the planning
-  nav2_costmap_2d::Costmap2D * costmap;
+  nav2_costmap_2d::Costmap2D * costmap = _costmap;
   if (_costmap_downsampler) {
-    costmap = _costmap_downsampler->downsample();
-  } else {
-    costmap = _costmap;
+    costmap = _costmap_downsampler->downsample(_downsampling_factor);
   }
 
   // Set Costmap


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #4  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Turtlebot3 simulation |

---

## Description of contribution in a few bullet points

* Added a `CostmapDownsampler` that creates a new costmap with the specified resolution. In short, this downsampler inspects the subcells of the original costmap and assigns the highest cost to the corresponding new downsampled cell.
* Added an overlay in Rviz to visualize this map, there's an example below

### Example with Willow world
Ran a few tests in the willow world, here's how the map looks after being downsampled from a 0.1m resolution to 0.3m

![downsampling](https://user-images.githubusercontent.com/16105100/87191144-16e2ea00-c2f4-11ea-8eeb-37b58bf66912.png)

**Comparison**
| Resolution (m) | Nodes expanded | Avg runtime (ms) |
| ------ | ----------- |-----|
| 0.1 | 67420 | ~160 |
| 0.3 | 5460 | ~20 |

**Runtime impact**: downsampling the map is only done once (the first time we create a path) and it takes around 5ms for a 566x108 cells map. It's computation time is vastly outweighted by the amount of less nodes expanded.

## Description of documentation updates required from your changes
* Added two new parameters for the smac planner: boolean for using the downsampler, and a float specifying the desired resolution for downsampling.

---

## Future work that may be required 

* Could consider other ways to downsample aside from just picking up the max
* Create test-suite for the downsampler. I could probably include this in this PR or leave it for #9 