### PR TITLE
Adding SE2 Node for Hybrid Sampling

### DIFF
--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -259,7 +259,7 @@ planner_server:
       allow_unknown: false              # allow traveling in unknown space
       travel_cost_scale: 0.8            # [0,1] metric for how much you value staying out of higher-cost spaces (higher more adverse)
       max_iterations: -1                # maximum total iterations to search for before returning
-      max_on_approach_iterations: 1000  # maximum number of iterations to attempt to reach goal once in tolerance
+      max_on_approach_iterations: 1000  # maximum number of iterations to attempt to reach goal once in tolerance, 2D only
       smooth_path: false                 # Whether to smooth searched path
       upsample_path: false              # Whether to upsample path after smoothing, recommend off unless controller requires
       motion_model_for_search: "DUBIN"  # 4, 8 connected; Dubin, Redds-Shepp, Balkcom-Mason

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -255,15 +255,16 @@ planner_server:
     GridBased:
       tolerance: 0.5                    # tolerance for planning if unable to reach exact pose, in meters
       downsample_costmap: false         # whether or not to downsample the map to the specified resolution
-      downsampling_factor: 3            # multiplier for the resolution of the costmap layer
+      downsampling_factor: 1            # multiplier for the resolution of the costmap layer
       allow_unknown: false              # allow traveling in unknown space
       travel_cost_scale: 0.8            # [0,1] metric for how much you value staying out of higher-cost spaces (higher more adverse)
       max_iterations: -1                # maximum total iterations to search for before returning
       max_on_approach_iterations: 1000  # maximum number of iterations to attempt to reach goal once in tolerance
-      smooth_path: true                 # Whether to smooth searched path
+      smooth_path: false                 # Whether to smooth searched path
       upsample_path: false              # Whether to upsample path after smoothing, recommend off unless controller requires
-      motion_model_for_search: "DUBIN"  # 8 connected
-      angle_quantization_bins: 8        # Number of angle bins for search, must be 1 for 2D node (no angle search)
+      motion_model_for_search: "DUBIN"  # 4, 8 connected; Dubin, Redds-Shepp, Balkcom-Mason
+      angle_quantization_bins: 72        # Number of angle bins for search, must be 1 for 2D node (no angle search)
+      minimum_turning_radius: 0.10       # minimum turning radius in m of your vehicle
 
       smoother:
         upsampling_ratio: 4

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -262,10 +262,10 @@ planner_server:
       max_on_approach_iterations: 1000  # maximum number of iterations to attempt to reach goal once in tolerance
       smooth_path: true                 # Whether to smooth searched path
       upsample_path: true               # Whether to upsample path after smoothing, recommend off unless controller requires
-      neighborhood_for_search: "MOORE"  # 8 connected
+      motion_model_for_search: "MOORE"  # 8 connected
 
       smoother:
-        sampling_ratio: 4
+        upsampling_ratio: 4
         # smoother weights
         # need to create weights for common resolutions (2.5, 5, 10)
         smoother:

--- a/nav2_bringup/bringup/params/nav2_params.yaml
+++ b/nav2_bringup/bringup/params/nav2_params.yaml
@@ -261,8 +261,9 @@ planner_server:
       max_iterations: -1                # maximum total iterations to search for before returning
       max_on_approach_iterations: 1000  # maximum number of iterations to attempt to reach goal once in tolerance
       smooth_path: true                 # Whether to smooth searched path
-      upsample_path: true               # Whether to upsample path after smoothing, recommend off unless controller requires
-      motion_model_for_search: "MOORE"  # 8 connected
+      upsample_path: false              # Whether to upsample path after smoothing, recommend off unless controller requires
+      motion_model_for_search: "DUBIN"  # 8 connected
+      angle_quantization_bins: 8        # Number of angle bins for search, must be 1 for 2D node (no angle search)
 
       smoother:
         upsampling_ratio: 4

--- a/smac_planner/CMakeLists.txt
+++ b/smac_planner/CMakeLists.txt
@@ -52,6 +52,8 @@ set(dependencies
 add_library(${library_name} SHARED
   src/a_star.cpp
   src/smac_planner.cpp
+  src/node_se2.cpp
+  src/node_2d.cpp
 )
 
 ament_target_dependencies(${library_name}
@@ -82,5 +84,5 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_libraries(${library_name})
-ament_export_dependencies(${dependencies} Eigen3)
+ament_export_dependencies(${dependencies})
 ament_package()

--- a/smac_planner/CMakeLists.txt
+++ b/smac_planner/CMakeLists.txt
@@ -49,26 +49,44 @@ set(dependencies
   eigen3_cmake_module
 )
 
+# SE2 plugin
 add_library(${library_name} SHARED
-  src/a_star.cpp
   src/smac_planner.cpp
+  src/a_star.cpp
   src/node_se2.cpp
   src/costmap_downsampler.cpp
   src/node_2d.cpp
 )
 
+target_link_libraries(${library_name} ${CERES_LIBRARIES})
+target_include_directories(${library_name} PUBLIC ${Eigen3_INCLUDE_DIRS})
+
 ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-target_include_directories(${library_name} PUBLIC ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${library_name} ${CERES_LIBRARIES})
+# 2D plugin
+add_library(${library_name}_2d SHARED
+  src/smac_planner_2d.cpp
+  src/a_star.cpp
+  src/node_se2.cpp
+  src/costmap_downsampler.cpp
+  src/node_2d.cpp
+)
+
+target_link_libraries(${library_name}_2d ${CERES_LIBRARIES})
+target_include_directories(${library_name}_2d PUBLIC ${Eigen3_INCLUDE_DIRS})
+
+ament_target_dependencies(${library_name}_2d
+  ${dependencies}
+)
 
 target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_compile_definitions(${library_name}_2d PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 pluginlib_export_plugin_description_file(nav2_core ${plugin_xml})
 
-install(TARGETS ${library_name}
+install(TARGETS ${library_name} ${library_name}_2d
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -84,6 +102,6 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${library_name})
+ament_export_libraries(${library_name} ${library_name}_2d)
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/smac_planner/CMakeLists.txt
+++ b/smac_planner/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(${library_name} SHARED
   src/a_star.cpp
   src/smac_planner.cpp
   src/node_se2.cpp
+  src/costmap_downsampler.cpp
   src/node_2d.cpp
 )
 

--- a/smac_planner/global_planner_plugin.xml
+++ b/smac_planner/global_planner_plugin.xml
@@ -1,5 +1,10 @@
 <library path="smac_planner">
 	<class name="smac_planner/SmacPlanner" type="smac_planner::SmacPlanner" base_class_type="nav2_core::GlobalPlanner">
-	  <description></description>
+	  <description>SE2 version of the SMAC planner</description>
 	</class>
+</library>
+<library path="smac_planner_2d">
+  <class name="smac_planner/SmacPlanner2D" type="smac_planner::SmacPlanner2D" base_class_type="nav2_core::GlobalPlanner">
+    <description>2D version of the SMAC Planner</description>
+  </class>
 </library>

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -161,21 +161,6 @@ private:
   inline void addNode(const float cost, NodePtr & node);
 
   /**
-   * @brief Retrieve all valid neighbors of a node.
-   * @param node Pointer to the node we are currently exploring in A*
-   * @param neighbors Vector of neighbors to be filled
-   */
-  inline void getNeighbors(NodePtr & node, NodeVector & neighbors);
-
-  /**
-   * @brief Initialize the neighborhood to be used in A*
-   * For now we support 4-connect (VON_NEUMANN) and 8-connect (MOORE)
-   * @param x_size The size of the underlying grid
-   * @param neighborhood The desired neighborhood type
-   */
-  inline void initNeighborhoods(const int & x_size, const Neighborhood & neighborhood);
-
-  /**
    * @brief Check if this node is the goal node
    * @param node Node pointer to check if its the goal node
    * @return if node is goal
@@ -257,7 +242,6 @@ private:
   std::unique_ptr<NodeQueue> _queue;
 
   Neighborhood _neighborhood;
-  std::vector<int> _neighbors_grid_offsets;
   NodeHeuristicPair _best_heuristic_node;
 };
 

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -102,7 +102,7 @@ public:
 
   /**
    * @brief Create the graph based on the node type. For 2D nodes, a cost grid.
-   *   For 3D nodes, a SE2 grid without cost info as needs collision detector for footprint. 
+   *   For 3D nodes, a SE2 grid without cost info as needs collision detector for footprint.
    * @param x The total number of nodes in the X direction
    * @param y The total number of nodes in the X direction
    * @param costs unsigned char * to the costs in the graph
@@ -201,7 +201,7 @@ private:
   inline bool areInputsValid();
 
   /**
-   * @brief Get maximum number of on-approach iterations after within threshold 
+   * @brief Get maximum number of on-approach iterations after within threshold
    * @return Reference to Maximum on-appraoch iterations parameter
    */
   inline int & getOnApproachMaxIterations();

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -22,7 +22,8 @@
 #include <queue>
 #include <utility>
 
-#include "smac_planner/node.hpp"
+#include "smac_planner/node_2d.hpp"
+#include "smac_planner/node_3d.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/constants.hpp"
 
@@ -41,7 +42,7 @@ public:
   typedef std::vector<NodeT> Graph;
   typedef std::vector<NodePtr> NodeVector;
   typedef std::pair<float, NodePtr> NodeElement;
-  typedef std::pair<float, unsigned int> NodeHeuristicPair;
+  typedef typename NodeT::Coordinates Coordinates;
 
   struct NodeComparator
   {
@@ -89,12 +90,13 @@ public:
   bool createPath(IndexPath & path, int & num_iterations, const float & tolerance);
 
   /**
-   * @brief Set the costs of the graph
+   * @brief Create the graph based on the node type. For 2D nodes, a cost grid.
+   *   For 3D nodes, a SE2 grid without cost info as needs collision detector for footprint. 
    * @param x The total number of nodes in the X direction
    * @param y The total number of nodes in the X direction
    * @param costs unsigned char * to the costs in the graph
    */
-  void setCosts(
+  void createGraph(
     const unsigned int & x,
     const unsigned int & y,
     unsigned char * & costs);
@@ -187,7 +189,7 @@ private:
    * @param node Node index of new
    * @return Heuristic cost between the nodes
    */
-  inline float getHeuristicCost(const unsigned int & node);
+  inline float getHeuristicCost(const NodePtr & node);
 
   /**
    * @brief Check if inputs to planner are valid
@@ -220,11 +222,10 @@ private:
   inline unsigned int & getSizeY();
 
   /**
-   * @brief Get node coordinates from index
-   * @param index Index of node
-   * @return pair of XY coordinates
+   * @brief Get number of angle quantization bins
+   * @return Number of angle bins
    */
-  inline Coordinates getCoords(const unsigned int & index);
+  inline unsigned int & getSizeTheta();
 
   /**
    * @brief Clear hueristic queue of nodes to search
@@ -239,6 +240,7 @@ private:
   float _tolerance;
   unsigned int _x_size;
   unsigned int _y_size;
+  unsigned int _angle_quantization;
 
   Coordinates _goal_coordinates;
   NodePtr _start;

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -21,13 +21,24 @@
 #include <memory>
 #include <queue>
 #include <utility>
+#include "Eigen/Core"
 
 #include "smac_planner/node_2d.hpp"
 #include "smac_planner/node_se2.hpp"
 #include "smac_planner/types.hpp"
+#include "smac_planner/constants.hpp"
 
 namespace smac_planner
 {
+
+inline double squaredDistance(
+  const Eigen::Vector2d & p1,
+  const Eigen::Vector2d & p2)
+{
+  const double & dx = p1[0] - p2[0];
+  const double & dy = p1[1] - p2[1];
+  return hypot(dx, dy);
+}
 
 /**
  * @class smac_planner::AStarAlgorithm
@@ -57,7 +68,7 @@ public:
    * @brief A constructor for smac_planner::PlannerServer
    * @param neighborhood The type of neighborhood to use for search (4 or 8 connected)
    */
-  explicit AStarAlgorithm(const MotionModel & motion_model);
+  explicit AStarAlgorithm(const MotionModel & motion_model, const float & min_turning_radius);
 
   /**
    * @brief A destructor for smac_planner::AStarAlgorithm
@@ -232,6 +243,7 @@ private:
   unsigned int _x_size;
   unsigned int _y_size;
   unsigned int _dim3_size;
+  float _min_turning_radius;
 
   Coordinates _goal_coordinates;
   NodePtr _start;

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -25,7 +25,6 @@
 #include "smac_planner/node_2d.hpp"
 #include "smac_planner/node_se2.hpp"
 #include "smac_planner/types.hpp"
-#include "smac_planner/constants.hpp"
 
 namespace smac_planner
 {
@@ -58,7 +57,7 @@ public:
    * @brief A constructor for smac_planner::PlannerServer
    * @param neighborhood The type of neighborhood to use for search (4 or 8 connected)
    */
-  explicit AStarAlgorithm(const Neighborhood & neighborhood);
+  explicit AStarAlgorithm(const MotionModel & motion_model);
 
   /**
    * @brief A destructor for smac_planner::AStarAlgorithm
@@ -241,7 +240,7 @@ private:
   std::unique_ptr<Graph> _graph;
   std::unique_ptr<NodeQueue> _queue;
 
-  Neighborhood _neighborhood;
+  MotionModel _motion_model;
   NodeHeuristicPair _best_heuristic_node;
 };
 

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 
 #include "smac_planner/node_2d.hpp"
-#include "smac_planner/node_3d.hpp"
+#include "smac_planner/node_se2.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/constants.hpp"
 
@@ -99,19 +99,26 @@ public:
   void createGraph(
     const unsigned int & x,
     const unsigned int & y,
+    const unsigned int & theta,
     unsigned char * & costs);
 
   /**
    * @brief Set the goal for planning, as a node index
    * @param value The node index of the goal
    */
-  void setGoal(const unsigned int & value);
+  void setGoal(
+    const unsigned int & mx,
+    const unsigned int & my,
+    const unsigned int & theta);
 
   /**
    * @brief Set the starting pose for planning, as a node index
    * @param value The node index of the start
    */
-  void setStart(const unsigned int & value);
+  void setStart(
+    const unsigned int & mx,
+    const unsigned int & my,
+    const unsigned int & theta);
 
   /**
    * @brief Set the starting pose for planning, as a node index
@@ -222,10 +229,10 @@ private:
   inline unsigned int & getSizeY();
 
   /**
-   * @brief Get number of angle quantization bins
-   * @return Number of angle bins
+   * @brief Get number of angle quantization bins (SE2) or Z coordinate  (XYZ)
+   * @return Number of angle bins / Z dimension
    */
-  inline unsigned int & getSizeTheta();
+  inline unsigned int & getSizeDim3();
 
   /**
    * @brief Clear hueristic queue of nodes to search
@@ -240,7 +247,7 @@ private:
   float _tolerance;
   unsigned int _x_size;
   unsigned int _y_size;
-  unsigned int _angle_quantization;
+  unsigned int _dim3_size;
 
   Coordinates _goal_coordinates;
   NodePtr _start;

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -110,7 +110,7 @@ public:
   void createGraph(
     const unsigned int & x,
     const unsigned int & y,
-    const unsigned int & theta,
+    const unsigned int & dim_3,
     unsigned char * & costs);
 
   /**
@@ -120,7 +120,7 @@ public:
   void setGoal(
     const unsigned int & mx,
     const unsigned int & my,
-    const unsigned int & theta);
+    const unsigned int & dim_3);
 
   /**
    * @brief Set the starting pose for planning, as a node index
@@ -129,7 +129,7 @@ public:
   void setStart(
     const unsigned int & mx,
     const unsigned int & my,
-    const unsigned int & theta);
+    const unsigned int & dim_3);
 
   /**
    * @brief Set the starting pose for planning, as a node index

--- a/smac_planner/include/smac_planner/a_star.hpp
+++ b/smac_planner/include/smac_planner/a_star.hpp
@@ -53,6 +53,7 @@ public:
   typedef std::vector<NodePtr> NodeVector;
   typedef std::pair<float, NodePtr> NodeElement;
   typedef typename NodeT::Coordinates Coordinates;
+  typedef typename NodeT::CoordinateVector CoordinateVector;
 
   struct NodeComparator
   {
@@ -97,7 +98,7 @@ public:
    * @param tolerance Reference to tolerance in costmap nodes
    * @return if plan was successful
    */
-  bool createPath(IndexPath & path, int & num_iterations, const float & tolerance);
+  bool createPath(CoordinateVector & path, int & num_iterations, const float & tolerance);
 
   /**
    * @brief Create the graph based on the node type. For 2D nodes, a cost grid.
@@ -136,7 +137,7 @@ public:
    * @param path Reference to a vector of indicies of generated path
    * @return whether the path was able to be backtraced
    */
-  bool backtracePath(NodePtr & node, IndexPath & path);
+  bool backtracePath(NodePtr & node, CoordinateVector & path);
 
   /**
    * @brief Get maximum number of iterations to plan

--- a/smac_planner/include/smac_planner/constants.hpp
+++ b/smac_planner/include/smac_planner/constants.hpp
@@ -22,7 +22,7 @@ namespace smac_planner
     UNKNOWN = 0,
     VON_NEUMANN = 1,
     MOORE = 2,
-    DUBLIN = 3,
+    DUBIN = 3,
     REEDS_SHEPP = 4,
     BALKCOM_MASON = 5,
   };
@@ -34,8 +34,8 @@ namespace smac_planner
         return "Von Neumann";
       case MotionModel::MOORE:
         return "Moore";
-      case MotionModel::DUBLIN:
-        return "Dublin";
+      case MotionModel::DUBIN:
+        return "Dubin";
       case MotionModel::REEDS_SHEPP:
         return "Reeds-Shepp";
       case MotionModel::BALKCOM_MASON:
@@ -51,8 +51,8 @@ namespace smac_planner
       return MotionModel::VON_NEUMANN;
     } else if (n == "MOORE") {
       return MotionModel::MOORE;
-    } else if (n == "DUBLIN") {
-      return MotionModel::DUBLIN;
+    } else if (n == "DUBIN") {
+      return MotionModel::DUBIN;
     } else if (n == "REEDS_SHEPP") {
       return MotionModel::REEDS_SHEPP;
     } else if (n == "BALKCOM_MASON") {

--- a/smac_planner/include/smac_planner/constants.hpp
+++ b/smac_planner/include/smac_planner/constants.hpp
@@ -17,56 +17,56 @@
 
 namespace smac_planner
 {
-  enum class MotionModel
-  {
-    UNKNOWN = 0,
-    VON_NEUMANN = 1,
-    MOORE = 2,
-    DUBIN = 3,
-    REEDS_SHEPP = 4,
-    // BALKCOM_MASON = 5,
-  };
+enum class MotionModel
+{
+  UNKNOWN = 0,
+  VON_NEUMANN = 1,
+  MOORE = 2,
+  DUBIN = 3,
+  REEDS_SHEPP = 4,
+  // BALKCOM_MASON = 5,
+};
 
-  inline std::string toString(const MotionModel & n)
-  {
-    switch (n) {
-      case MotionModel::VON_NEUMANN:
-        return "Von Neumann";
-      case MotionModel::MOORE:
-        return "Moore";
-      case MotionModel::DUBIN:
-        return "Dubin";
-      case MotionModel::REEDS_SHEPP:
-        return "Reeds-Shepp";
-      // case MotionModel::BALKCOM_MASON:
-      //   return "Balkcom-Mason";
-      default:
-        return "Unknown";
-    }
+inline std::string toString(const MotionModel & n)
+{
+  switch (n) {
+    case MotionModel::VON_NEUMANN:
+      return "Von Neumann";
+    case MotionModel::MOORE:
+      return "Moore";
+    case MotionModel::DUBIN:
+      return "Dubin";
+    case MotionModel::REEDS_SHEPP:
+      return "Reeds-Shepp";
+    // case MotionModel::BALKCOM_MASON:
+    //   return "Balkcom-Mason";
+    default:
+      return "Unknown";
   }
+}
 
-  inline MotionModel fromString(const std::string & n)
-  {
-    if (n == "VON_NEUMANN") {
-      return MotionModel::VON_NEUMANN;
-    } else if (n == "MOORE") {
-      return MotionModel::MOORE;
-    } else if (n == "DUBIN") {
-      return MotionModel::DUBIN;
-    } else if (n == "REEDS_SHEPP") {
-      return MotionModel::REEDS_SHEPP;
+inline MotionModel fromString(const std::string & n)
+{
+  if (n == "VON_NEUMANN") {
+    return MotionModel::VON_NEUMANN;
+  } else if (n == "MOORE") {
+    return MotionModel::MOORE;
+  } else if (n == "DUBIN") {
+    return MotionModel::DUBIN;
+  } else if (n == "REEDS_SHEPP") {
+    return MotionModel::REEDS_SHEPP;
     // } else if (n == "BALKCOM_MASON") {
     //   return MotionModel::BALKCOM_MASON;
-    } else {
-      return MotionModel::UNKNOWN; 
-    }
+  } else {
+    return MotionModel::UNKNOWN;
   }
+}
 
-  const float UNKNOWN = 255;
-  const float OCCUPIED = 254;
-  const float INSCRIBED = 253;
-  const float MAX_NON_OBSTACLE = 252;
-  const float FREE = 0;
+const float UNKNOWN = 255;
+const float OCCUPIED = 254;
+const float INSCRIBED = 253;
+const float MAX_NON_OBSTACLE = 252;
+const float FREE = 0;
 
 }  // namespace smac_planner
 

--- a/smac_planner/include/smac_planner/constants.hpp
+++ b/smac_planner/include/smac_planner/constants.hpp
@@ -17,22 +17,48 @@
 
 namespace smac_planner
 {
-  enum class Neighborhood
+  enum class MotionModel
   {
     UNKNOWN = 0,
     VON_NEUMANN = 1,
-    MOORE = 2
+    MOORE = 2,
+    DUBLIN = 3,
+    REEDS_SHEPP = 4,
+    BALKCOM_MASON = 5,
   };
 
-  inline std::string toString(const Neighborhood & n)
+  inline std::string toString(const MotionModel & n)
   {
     switch (n) {
-      case Neighborhood::VON_NEUMANN:
+      case MotionModel::VON_NEUMANN:
         return "Von Neumann";
-      case Neighborhood::MOORE:
+      case MotionModel::MOORE:
         return "Moore";
+      case MotionModel::DUBLIN:
+        return "Dublin";
+      case MotionModel::REEDS_SHEPP:
+        return "Reeds-Shepp";
+      case MotionModel::BALKCOM_MASON:
+        return "Balkcom-Mason";
       default:
         return "Unknown";
+    }
+  }
+
+  inline MotionModel fromString(const std::string & n)
+  {
+    if (n == "VON_NEUMANN") {
+      return MotionModel::VON_NEUMANN;
+    } else if (n == "MOORE") {
+      return MotionModel::MOORE;
+    } else if (n == "DUBLIN") {
+      return MotionModel::DUBLIN;
+    } else if (n == "REEDS_SHEPP") {
+      return MotionModel::REEDS_SHEPP;
+    } else if (n == "BALKCOM_MASON") {
+      return MotionModel::BALKCOM_MASON;
+    } else {
+      return MotionModel::UNKNOWN; 
     }
   }
 

--- a/smac_planner/include/smac_planner/constants.hpp
+++ b/smac_planner/include/smac_planner/constants.hpp
@@ -24,7 +24,7 @@ namespace smac_planner
     MOORE = 2,
     DUBIN = 3,
     REEDS_SHEPP = 4,
-    BALKCOM_MASON = 5,
+    // BALKCOM_MASON = 5,
   };
 
   inline std::string toString(const MotionModel & n)
@@ -38,8 +38,8 @@ namespace smac_planner
         return "Dubin";
       case MotionModel::REEDS_SHEPP:
         return "Reeds-Shepp";
-      case MotionModel::BALKCOM_MASON:
-        return "Balkcom-Mason";
+      // case MotionModel::BALKCOM_MASON:
+      //   return "Balkcom-Mason";
       default:
         return "Unknown";
     }
@@ -55,8 +55,8 @@ namespace smac_planner
       return MotionModel::DUBIN;
     } else if (n == "REEDS_SHEPP") {
       return MotionModel::REEDS_SHEPP;
-    } else if (n == "BALKCOM_MASON") {
-      return MotionModel::BALKCOM_MASON;
+    // } else if (n == "BALKCOM_MASON") {
+    //   return MotionModel::BALKCOM_MASON;
     } else {
       return MotionModel::UNKNOWN; 
     }

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -47,7 +47,7 @@ public:
    * @param costmap The costmap we want to downsample
    * @param downsampling_factor Multiplier for the costmap resolution
    */
-   void initialize(
+  void initialize(
     const std::string & global_frame,
     const std::string & topic_name,
     nav2_costmap_2d::Costmap2D * const costmap,
@@ -56,14 +56,16 @@ public:
   /**
    * @brief Activate the publisher of the downsampled costmap
    */
-  void activatePublisher() {
+  void activatePublisher()
+  {
     _downsampled_costmap_pub->on_activate();
   }
 
   /**
    * @brief Deactivate the publisher of the downsampled costmap
    */
-  void deactivatePublisher() {
+  void deactivatePublisher()
+  {
     _downsampled_costmap_pub->on_deactivate();
   }
 

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -19,6 +19,8 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "smac_planner/constants.hpp"
 
+// TODO make cpp file for functional bits
+
 namespace smac_planner
 {
 

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -19,8 +19,6 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "smac_planner/constants.hpp"
 
-// TODO make cpp file for functional bits
-
 namespace smac_planner
 {
 
@@ -35,20 +33,12 @@ public:
    * @brief A constructor for CostmapDownsampler
    * @param node Lifecycle node pointer
    */
-  explicit CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node)
-  : _costmap(nullptr),
-    _downsampled_costmap(nullptr),
-    _downsampled_costmap_pub(nullptr),
-    _node(node)
-  {
-  }
+  explicit CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node);
 
   /**
    * @brief A destructor for CostmapDownsampler
    */
-  ~CostmapDownsampler()
-  {
-  }
+  ~CostmapDownsampler();
 
   /**
    * @brief Initialize the downsampled costmap object and the ROS publisher
@@ -61,20 +51,7 @@ public:
     const std::string & global_frame,
     const std::string & topic_name,
     nav2_costmap_2d::Costmap2D * const costmap,
-    const unsigned int & downsampling_factor)
-  {
-    _topic_name = topic_name;
-    _costmap = costmap;
-    _downsampling_factor = downsampling_factor;
-    updateCostmapSize();
-
-    _downsampled_costmap = std::make_unique<nav2_costmap_2d::Costmap2D>
-      (_downsampled_size_x, _downsampled_size_y, _downsampled_resolution,
-       _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
-
-    _downsampled_costmap_pub = std::make_unique<nav2_costmap_2d::Costmap2DPublisher>(
-      _node, _downsampled_costmap.get(), global_frame, _topic_name, false);
-  }
+    const unsigned int & downsampling_factor);
 
   /**
    * @brief Activate the publisher of the downsampled costmap
@@ -95,58 +72,17 @@ public:
    * @param downsampling_factor Multiplier for the costmap resolution
    * @return A ptr to the downsampled costmap
    */
-  nav2_costmap_2d::Costmap2D * downsample(const unsigned int & downsampling_factor)
-  {
-    _downsampling_factor = downsampling_factor;
-    updateCostmapSize();
-
-    // Adjust costmap size if needed
-    if (_downsampled_costmap->getSizeInCellsX() != _downsampled_size_x ||
-      _downsampled_costmap->getSizeInCellsY() != _downsampled_size_y ||
-      _downsampled_costmap->getResolution() != _downsampled_resolution) {
-      resizeCostmap();
-    }
-
-    // Assign costs
-    for (int i = 0; i < _downsampled_size_x; ++i) {
-      for (int j = 0; j < _downsampled_size_y; ++j) {
-        setCostOfCell(i, j);
-      }
-    }
-
-    if (_node->count_subscribers(_topic_name) > 0) {
-      _downsampled_costmap_pub->publishCostmap();
-    }
-
-    return _downsampled_costmap.get();
-  }
+  nav2_costmap_2d::Costmap2D * downsample(const unsigned int & downsampling_factor);
 
 private:
   /**
    * Update the sizes X-Y of the costmap and its downsampled version
    */
-  void updateCostmapSize()
-  {
-    _size_x = _costmap->getSizeInCellsX();
-    _size_y = _costmap->getSizeInCellsY();
-    _downsampled_size_x = ceil(static_cast<float>(_size_x) / _downsampling_factor);
-    _downsampled_size_y = ceil(static_cast<float>(_size_y) / _downsampling_factor);
-    _downsampled_resolution = _downsampling_factor * _costmap->getResolution();
-  }
-
+  void updateCostmapSize();
   /**
    * Resize the downsampled costmap. Used in case the costmap changes and we need to update the downsampled version
    */
-  void resizeCostmap()
-  {
-    _downsampled_costmap->resizeMap(
-      _downsampled_size_x,
-      _downsampled_size_y,
-      _downsampled_resolution,
-      _costmap->getOriginX(),
-      _costmap->getOriginY());
-  }
-
+  void resizeCostmap();
   /**
    * @brief Explore all subcells of the original costmap and assign the max cost to the new (downsampled) cell
    * @param new_mx The X-coordinate of the cell in the new costmap
@@ -154,29 +90,7 @@ private:
    */
   void setCostOfCell(
     const unsigned int & new_mx,
-    const unsigned int & new_my)
-  {
-    unsigned int mx, my;
-    unsigned char cost = 0;
-    unsigned int x_offset = new_mx * _downsampling_factor;
-    unsigned int y_offset = new_my * _downsampling_factor;
-
-    for (int i = 0; i < _downsampling_factor; ++i) {
-      mx = x_offset + i;
-      if (mx >= _size_x) {
-        continue;
-      }
-      for (int j = 0; j < _downsampling_factor; ++j) {
-        my = y_offset + j;
-        if (my >= _size_y) {
-          continue;
-        }
-        cost = std::max(cost, _costmap->getCost(mx, my));
-      }
-    }
-
-    _downsampled_costmap->setCost(new_mx, new_my, cost);
-  }
+    const unsigned int & new_my);
 
   unsigned int _size_x;
   unsigned int _size_y;

--- a/smac_planner/include/smac_planner/minimal_costmap.hpp
+++ b/smac_planner/include/smac_planner/minimal_costmap.hpp
@@ -45,7 +45,7 @@ public:
   MinimalCostmap(
     unsigned char * & char_costmap,
     const unsigned int & size_x,
-    const unsigned int & size_y, 
+    const unsigned int & size_y,
     const double & origin_x,
     const double & origin_y,
     const double & resolution)
@@ -77,7 +77,9 @@ public:
    * @param wy Double world coords Y
    * @return if successful
    */
-  inline bool worldToMap(const double & wx, const double & wy, unsigned int & mx, unsigned int & my) const
+  inline bool worldToMap(
+    const double & wx, const double & wy, unsigned int & mx,
+    unsigned int & my) const
   {
     if (wx < _origin_x || wy < _origin_y) {
       return false;

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -15,10 +15,13 @@
 #ifndef SMAC_PLANNER__NODE_2D_HPP_
 #define SMAC_PLANNER__NODE_2D_HPP_
 
+#include <math.h>
 #include <vector>
 #include <iostream>
+#include <memory>
 #include <queue>
 #include <limits>
+#include <utility>
 #include <functional>
 
 #include "smac_planner/constants.hpp"
@@ -56,23 +59,12 @@ public:
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  explicit Node2D(unsigned char & cost_in, const unsigned int index)
-  : parent(nullptr),
-    _cell_cost(static_cast<float>(cost_in)),
-    _accumulated_cost(std::numeric_limits<float>::max()),
-    _index(index),
-    _was_visited(false),
-    _is_queued(false)
-  {
-  }
+  explicit Node2D(unsigned char & cost_in, const unsigned int index);
 
   /**
    * @brief A destructor for smac_planner::Node2D
    */
-  ~Node2D()
-  {
-    parent = nullptr;
-  }
+  ~Node2D();
 
   /**
    * @brief operator== for comparisons
@@ -89,16 +81,7 @@ public:
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  inline void reset(const unsigned char & cost, const unsigned int index)
-  {
-    parent = nullptr;
-    _cell_cost = static_cast<float>(cost);
-    _accumulated_cost = std::numeric_limits<float>::max();
-    _index = index;
-    _was_visited = false;
-    _is_queued = false;
-  }
-
+  void reset(const unsigned char & cost, const unsigned int index);
   /**
    * @brief Gets the accumulated cost at this node
    * @return accumulated cost
@@ -175,28 +158,7 @@ public:
    * @param traverse_unknown If we can explore unknown nodes on the graph
    * @return whether this node is valid and collision free
    */
-  inline bool isNodeValid(const bool & traverse_unknown) {
-    // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
-    // the regular grid (e.g. your node is on the edge of the costmap and i+1
-    // goes to the other side). This check would add compute time and my assertion is
-    // that if you do wrap around, the heuristic will be so high it'll be added far
-    // in the queue that it will never be called if a valid path exists.
-    // This is intentionally un-included to increase speed, but be aware. If this causes
-    // trouble, please file a ticket and we can address it then.
-
-    // occupied node
-    auto & cost = this->getCost();
-    if (cost == OCCUPIED || cost == INSCRIBED) {
-      return false;
-    }
-
-    // unknown node
-    if (cost == UNKNOWN && ! traverse_unknown) {
-      return false;
-    }
-
-    return true;
-  }
+  bool isNodeValid(const bool & traverse_unknown);
 
   static inline unsigned int getIndex(
     const unsigned int & x, const unsigned int & y, const unsigned int & width)
@@ -220,15 +182,9 @@ public:
    * @param node Node index of new
    * @return Heuristic cost between the nodes
    */
-  static inline float getHeuristicCost(
+  static float getHeuristicCost(
     const Coordinates & node_coords,
-    const Coordinates & goal_coordinates,
-    const float & neutral_cost)
-  {
-    return hypotf(
-      goal_coordinates.x - node_coords.x,
-      goal_coordinates.y - node_coords.y) * neutral_cost;
-  }
+    const Coordinates & goal_coordinates);
 
   /**
    * @brief Initialize the neighborhood to be used in A*
@@ -236,60 +192,19 @@ public:
    * @param x_size_uint The total x size to find neighbors
    * @param neighborhood The desired neighborhood type
    */
-  static inline void initNeighborhoods(
+  static void initNeighborhood(
     const unsigned int & x_size_uint,
-    const Neighborhood & neighborhood)
-  {
-    int x_size = static_cast<int>(x_size_uint);
-    switch (neighborhood) {
-      case Neighborhood::UNKNOWN:
-        throw std::runtime_error("Unknown neighborhood type selected.");
-      case Neighborhood::VON_NEUMANN:
-        _neighbors_grid_offsets = {-1, +1, -x_size, +x_size};
-        break;
-      case Neighborhood::MOORE:
-        _neighbors_grid_offsets = {-1, +1, -x_size, +x_size, -x_size - 1,
-                                   -x_size + 1, +x_size - 1, +x_size + 1};
-        break;
-      default:
-        throw std::runtime_error("Invalid neighborhood type selected.");
-    }
-  }
-
+    const MotionModel & neighborhood);
   /**
    * @brief Retrieve all valid neighbors of a node.
    * @param node Pointer to the node we are currently exploring in A*
    * @param graph Reference to graph to discover new nodes 
    * @param neighbors Vector of neighbors to be filled
    */
-  static inline void getNeighbors(
+  static void getNeighbors(
     NodePtr & node,
     std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validity_checker,
-    NodeVector & neighbors)
-  {
-    // NOTE(stevemacenski): Irritatingly, the order here matters. If you start in free
-    // space and then expand 8-connected, the first set of neighbors will be all cost
-    // _neutral_cost. Then its expansion will all be 2 * _neutral_cost but now multiple
-    // nodes are touching that node so the last cell to update the back pointer wins.
-    // Thusly, the ordering ends with the cardinal directions for both sets such that
-    // behavior is consistent in large free spaces between them.
-    // 100  50   0
-    // 100  50  50
-    // 100 100 100   where lower-middle '100' is visited with same cost by both bottom '50' nodes
-    // Therefore, it is valuable to have some low-potential across the entire map
-    // rather than a small inflation around the obstacles
-    int index;
-    NodePtr neighbor;
-    int node_i = node->getIndex();
-
-    for(unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
-      index = node_i + _neighbors_grid_offsets[i];
-      if (index > 0 && validity_checker(index, neighbor))
-      {
-        neighbors.push_back(neighbor);
-      }
-    }
-  }
+    NodeVector & neighbors);
 
   Node2D * parent;
 

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
-#ifndef SMAC_PLANNER__NODE_HPP_
-#define SMAC_PLANNER__NODE_HPP_
+#ifndef SMAC_PLANNER__NODE_2D_HPP_
+#define SMAC_PLANNER__NODE_2D_HPP_
 
 #include <vector>
 #include <iostream>
@@ -26,18 +26,33 @@ namespace smac_planner
 {
 
 /**
- * @class smac_planner::Node
- * @brief Node implementation for graph
+ * @class smac_planner::Node2D
+ * @brief Node2D implementation for graph
  */
-class Node
+class Node2D
 {
 public:
+
   /**
-   * @brief A constructor for smac_planner::Node
+   * @class smac_planner::Node2D::Coordinates
+   * @brief Node2D implementation of coordinate structure
+   */
+  struct Coordinates
+  {
+    Coordinates() {};
+    Coordinates(const float & x_in, const float & y_in)
+    : x(x_in), y(y_in)
+    {};
+    
+    float x, y; 
+  };
+
+  /**
+   * @brief A constructor for smac_planner::Node2D
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  explicit Node(unsigned char & cost_in, const unsigned int index)
+  explicit Node2D(unsigned char & cost_in, const unsigned int index)
   : parent(nullptr),
     _cell_cost(static_cast<float>(cost_in)),
     _accumulated_cost(std::numeric_limits<float>::max()),
@@ -48,19 +63,19 @@ public:
   }
 
   /**
-   * @brief A destructor for smac_planner::Node
+   * @brief A destructor for smac_planner::Node2D
    */
-  ~Node()
+  ~Node2D()
   {
     parent = nullptr;
   }
 
   /**
    * @brief operator== for comparisons
-   * @param Node right hand side node reference
+   * @param Node2D right hand side node reference
    * @return If cell indicies are equal
    */
-  bool operator==(const Node & rhs)
+  bool operator==(const Node2D & rhs)
   {
     return this->_index == rhs._index;
   }
@@ -179,7 +194,39 @@ public:
     return true;
   }
 
-  Node * parent;
+  static inline unsigned int getIndex(
+    const unsigned int & x, const unsigned int & y, const unsigned int & width)
+  {
+    return x + y * width;
+  }
+
+  static inline Coordinates getCoords(
+    const unsigned int & index, const unsigned int & width, const unsigned int & angles)
+  {
+    if (angles != 1) {
+      throw std::runtime_error("Node type Node2D does not have a valid angle quantization.");
+    }
+
+    return Coordinates(index % width, index / width);
+  }
+
+  /**
+   * @brief Get cost of heuristic of node
+   * @param node Node index current
+   * @param node Node index of new
+   * @return Heuristic cost between the nodes
+   */
+  static float getHeuristicCost(
+    const Coordinates & node_coords,
+    const Coordinates & goal_coordinates,
+    const float & neutral_cost)
+  {
+    return hypotf(
+      goal_coordinates.x - node_coords.x,
+      goal_coordinates.y - node_coords.y) * neutral_cost;
+  }
+
+  Node2D * parent;
 
 private:
   float _cell_cost;
@@ -191,4 +238,4 @@ private:
 
 }  // namespace smac_planner
 
-#endif  // SMAC_PLANNER__NODE_HPP_
+#endif  // SMAC_PLANNER__NODE_2D_HPP_

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -53,6 +53,7 @@ public:
     
     float x, y; 
   };
+  typedef std::vector<Coordinates> CoordinateVector;
 
   /**
    * @brief A constructor for smac_planner::Node2D

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -85,7 +85,7 @@ public:
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  void reset(const unsigned char & cost, const unsigned int index)
+  inline void reset(const unsigned char & cost, const unsigned int index)
   {
     parent = nullptr;
     _cell_cost = static_cast<float>(cost);
@@ -99,7 +99,7 @@ public:
    * @brief Gets the accumulated cost at this node
    * @return accumulated cost
    */
-  float & getAccumulatedCost()
+  inline float & getAccumulatedCost()
   {
     return _accumulated_cost;
   }
@@ -108,7 +108,7 @@ public:
    * @brief Sets the accumulated cost at this node
    * @param reference to accumulated cost
    */
-  void setAccumulatedCost(const float cost_in)
+  inline void setAccumulatedCost(const float cost_in)
   {
     _accumulated_cost = cost_in;
   }
@@ -117,7 +117,7 @@ public:
    * @brief Gets the costmap cost at this node
    * @return costmap cost
    */
-  float & getCost()
+  inline float & getCost()
   {
     return _cell_cost;
   }
@@ -126,7 +126,7 @@ public:
    * @brief Gets if cell has been visited in search
    * @param If cell was visited
    */
-  bool & wasVisited()
+  inline bool & wasVisited()
   {
     return _was_visited;
   }
@@ -134,7 +134,7 @@ public:
   /**
    * @brief Sets if cell has been visited in search
    */
-  void visited()
+  inline void visited()
   {
     _was_visited = true;
     _is_queued = false;
@@ -144,7 +144,7 @@ public:
    * @brief Gets if cell is currently queued in search
    * @param If cell was queued
    */
-  bool & isQueued()
+  inline bool & isQueued()
   {
     return _is_queued;
   }
@@ -152,7 +152,7 @@ public:
   /**
    * @brief Sets if cell is currently queued in search
    */
-  void queued()
+  inline void queued()
   {
     _is_queued = true;
   }
@@ -161,7 +161,7 @@ public:
    * @brief Gets cell index
    * @return Reference to cell index
    */
-  unsigned int & getIndex()
+  inline unsigned int & getIndex()
   {
     return _index;
   }
@@ -171,7 +171,7 @@ public:
    * @param traverse_unknown If we can explore unknown nodes on the graph
    * @return whether this node is valid and collision free
    */
-  bool isNodeValid(const bool & traverse_unknown) {
+  inline bool isNodeValid(const bool & traverse_unknown) {
     // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
     // the regular grid (e.g. your node is on the edge of the costmap and i+1
     // goes to the other side). This check would add compute time and my assertion is
@@ -216,7 +216,7 @@ public:
    * @param node Node index of new
    * @return Heuristic cost between the nodes
    */
-  static float getHeuristicCost(
+  static inline float getHeuristicCost(
     const Coordinates & node_coords,
     const Coordinates & goal_coordinates,
     const float & neutral_cost)

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -46,12 +46,12 @@ public:
    */
   struct Coordinates
   {
-    Coordinates() {};
+    Coordinates() {}
     Coordinates(const float & x_in, const float & y_in)
     : x(x_in), y(y_in)
-    {};
-    
-    float x, y; 
+    {}
+
+    float x, y;
   };
   typedef std::vector<Coordinates> CoordinateVector;
 
@@ -199,12 +199,12 @@ public:
   /**
    * @brief Retrieve all valid neighbors of a node.
    * @param node Pointer to the node we are currently exploring in A*
-   * @param graph Reference to graph to discover new nodes 
+   * @param graph Reference to graph to discover new nodes
    * @param neighbors Vector of neighbors to be filled
    */
   static void getNeighbors(
     NodePtr & node,
-    std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validity_checker,
+    std::function<bool(const unsigned int &, smac_planner::Node2D * &)> & validity_checker,
     NodeVector & neighbors);
 
   Node2D * parent;

--- a/smac_planner/include/smac_planner/node_3d.hpp
+++ b/smac_planner/include/smac_planner/node_3d.hpp
@@ -1,0 +1,264 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#ifndef SMAC_PLANNER__NODE_3D_HPP_
+#define SMAC_PLANNER__NODE_3D_HPP_
+
+#include <vector>
+#include <iostream>
+#include <queue>
+#include <limits>
+
+#include "smac_planner/constants.hpp"
+
+namespace smac_planner
+{
+
+// TODO optimization: should we be constructing full SE2 graph at start?
+    // or only construct as we get in contact to expand!
+    // doesnt matter as much for 2D planner, but really will matter here
+    // might speed things up a bit. Reserve graph (full, 20%, whatever) but dont fill in.
+
+/**
+ * @class smac_planner::Node3D
+ * @brief Node3D implementation for graph
+ */
+class Node3D
+{
+public:
+
+  /**
+   * @class smac_planner::Node3D::Coordinates
+   * @brief Node3D implementation of coordinate structure
+   */
+  struct Coordinates
+  {
+    Coordinates() {};
+    Coordinates(const float & x_in, const float & y_in, const float & theta_in)
+    : x(x_in), y(y_in), theta(theta_in)
+    {};
+
+    float x, y, theta;
+  };
+
+  /**
+   * @brief A constructor for smac_planner::Node3D
+   * @param cost_in The costmap cost at this node
+   * @param index The index of this node for self-reference
+   */
+  explicit Node3D(unsigned char & cost_in, const unsigned int index)
+  : parent(nullptr),
+    _cell_cost(static_cast<float>(cost_in)),
+    _accumulated_cost(std::numeric_limits<float>::max()),
+    _index(index),
+    _was_visited(false),
+    _is_queued(false),
+    _x(0.0),
+    _y(0.0),
+    _theta(0.0)
+  {
+  }
+
+  /**
+   * @brief A destructor for smac_planner::Node3D
+   */
+  ~Node3D()
+  {
+    parent = nullptr;
+  }
+
+  /**
+   * @brief operator== for comparisons
+   * @param Node3D right hand side node reference
+   * @return If cell indicies are equal
+   */
+  bool operator==(const Node3D & rhs)
+  {
+    return this->_index == rhs._index;
+  }
+
+  /**
+   * @brief Reset method for new search
+   * @param cost_in The costmap cost at this node
+   * @param index The index of this node for self-reference
+   */
+  void reset(const unsigned char & cost, const unsigned int index)
+  {
+    parent = nullptr;
+    _cell_cost = static_cast<float>(cost);
+    _accumulated_cost = std::numeric_limits<float>::max();
+    _index = index;
+    _was_visited = false;
+    _is_queued = false;
+  }
+
+  /**
+   * @brief Gets the accumulated cost at this node
+   * @return accumulated cost
+   */
+  float & getAccumulatedCost()
+  {
+    return _accumulated_cost;
+  }
+
+  /**
+   * @brief Sets the accumulated cost at this node
+   * @param reference to accumulated cost
+   */
+  void setAccumulatedCost(const float cost_in)
+  {
+    _accumulated_cost = cost_in;
+  }
+
+  /**
+   * @brief Gets the costmap cost at this node
+   * @return costmap cost
+   */
+  float & getCost()
+  {
+    return _cell_cost;
+  }
+
+  /**
+   * @brief Gets if cell has been visited in search
+   * @param If cell was visited
+   */
+  bool & wasVisited()
+  {
+    return _was_visited;
+  }
+
+  /**
+   * @brief Sets if cell has been visited in search
+   */
+  void visited()
+  {
+    _was_visited = true;
+    _is_queued = false;
+  }
+
+  /**
+   * @brief Gets if cell is currently queued in search
+   * @param If cell was queued
+   */
+  bool & isQueued()
+  {
+    return _is_queued;
+  }
+
+  /**
+   * @brief Sets if cell is currently queued in search
+   */
+  void queued()
+  {
+    _is_queued = true;
+  }
+
+  /**
+   * @brief Gets cell index
+   * @return Reference to cell index
+   */
+  unsigned int & getIndex()
+  {
+    return _index;
+  }
+
+  /**
+   * @brief Check if this node is valid
+   * @param traverse_unknown If we can explore unknown nodes on the graph
+   * @return whether this node is valid and collision free
+   */
+  bool isNodeValid(const bool & traverse_unknown) {
+    // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
+    // the regular grid (e.g. your node is on the edge of the costmap and i+1
+    // goes to the other side). This check would add compute time and my assertion is
+    // that if you do wrap around, the heuristic will be so high it'll be added far
+    // in the queue that it will never be called if a valid path exists.
+    // This is intentionally un-included to increase speed, but be aware. If this causes
+    // trouble, please file a ticket and we can address it then.
+
+    // TODO: replace this check with the footprint checker for non-circular footprints
+      // with pointer to collision checker and pointer to the char costmap rather than storing cost at cell
+
+    // bool free = collision_checker_->isFree(_x, _y, _theta);
+    // if (!free) {
+    //   return traverse_unknown ? free == UNKNOWN : free;    
+    // } else {
+    //   return free;
+    // }
+
+    // occupied node
+    auto & cost = this->getCost();
+    if (cost == OCCUPIED || cost == INSCRIBED) {
+      return false;
+    }
+
+    // unknown node
+    if (cost == UNKNOWN && ! traverse_unknown) {
+      return false;
+    }
+
+    return true;
+  }
+
+  static inline unsigned int getIndex(
+    const unsigned int & x, const unsigned int & y, const unsigned int & angle,
+    const unsigned int & width, const unsigned int angle_quantization)
+  {
+    return angle + x * angle_quantization + y * width * angle_quantization;
+  }
+
+  static inline Coordinates getCoords(
+    const unsigned int & index,
+    const unsigned int & width, const unsigned int angle_quantization)
+  {
+    return Coordinates(
+        (index / angle_quantization) % width,  // x
+        index / (angle_quantization * width),  // y
+        index % angle_quantization);  // theta
+  }
+
+  /**
+   * @brief Get cost of heuristic of node
+   * @param node Node index current
+   * @param node Node index of new
+   * @return Heuristic cost between the nodes
+   */
+  static float getHeuristicCost(
+    const Coordinates & node_coords,
+    const Coordinates & goal_coordinates,
+    const float & neutral_cost)
+  {
+    // TODO hueristic based on distance OR cached static table from paper
+    return hypotf(
+      goal_coordinates.x - node_coords.x,
+      goal_coordinates.y - node_coords.y) * neutral_cost;
+  }
+
+  Node3D * parent;
+
+private:
+  float _cell_cost; // TODO temporary, to be repalced with pointer to collision detector
+  float _accumulated_cost;
+  unsigned int _index;
+  bool _was_visited;
+  bool _is_queued;
+  float _x;
+  float _y;
+  float _theta;
+};
+
+}  // namespace smac_planner
+
+#endif  // SMAC_PLANNER__NODE_3D_HPP_

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -29,16 +29,17 @@
 namespace smac_planner
 {
 
-struct Pose
+// Need seperate pose struct for motion table operations
+struct MotionPose
 {
-  Pose() {}
-  Pose(const float x, const float y, const float theta)
+  MotionPose() {}
+  MotionPose(const float x, const float y, const float theta)
   : _x(x), _y(y), _theta(theta)
   {}
 
-  Pose operator+(const Pose & rhs)
+  MotionPose operator+(const MotionPose & rhs)
   {
-    return Pose(rhs._x + _x, rhs._y + _y, rhs._theta + _theta);
+    return MotionPose(rhs._x + _x, rhs._y + _y, rhs._theta + _theta);
   }
 
   float _x;
@@ -46,7 +47,7 @@ struct Pose
   float _theta;
 };
 
-typedef std::vector<Pose> Poses;
+typedef std::vector<MotionPose> MotionPoses;
 
 // Must forward declare
 class NodeSE2;
@@ -67,10 +68,10 @@ struct MotionTable
     unsigned int & size_x_in,
     unsigned int & angle_quantization_in);
 
-  Poses getProjections(NodeSE2 * & node);
-  Pose getProjection(NodeSE2 * & node, const unsigned int & motion_index);
+  MotionPoses getProjections(NodeSE2 * & node);
+  MotionPose getProjection(NodeSE2 * & node, const unsigned int & motion_index);
   
-  std::vector<Pose> projections;
+  MotionPoses projections;
   unsigned int size_x;
   unsigned int num_angle_quantization;
 };
@@ -96,8 +97,20 @@ public:
     : x(x_in), y(y_in), theta(theta_in)
     {};
 
+  /**
+   * @brief operator+ for addition
+   * @param MotionPose right hand side reference
+   * @return Added MotionPose and Coordinate
+   */
+    MotionPose operator+(const MotionPose & rhs)
+    {
+      return MotionPose(rhs._x + x, rhs._y + y, rhs._theta + theta);
+    }
+
     float x, y, theta;
   };
+
+  typedef std::vector<Coordinates> CoordinateVector;
 
   /**
    * @brief A constructor for smac_planner::NodeSE2
@@ -125,7 +138,7 @@ public:
    * @brief setting continuous coordinate search poses (in partial-cells)
    * @param Pose pose
    */
-  inline void setPose(const Pose & pose_in)
+  inline void setPose(const Coordinates & pose_in)
   {
     pose = pose_in;
   }
@@ -260,7 +273,7 @@ public:
     NodeVector & neighbors);
 
   NodeSE2 * parent;
-  Pose pose;
+  Coordinates pose;
 
 private:
   float _cell_cost;

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -39,7 +39,9 @@ namespace smac_planner
 class NodeSE2
 {
 public:
-
+  typedef NodeSE2 * NodePtr;
+  typedef std::unique_ptr<std::vector<NodeSE2>> Graph;
+  typedef std::vector<NodePtr> NodeVector;
   /**
    * @class smac_planner::NodeSE2::Coordinates
    * @brief NodeSE2 implementation of coordinate structure
@@ -272,6 +274,43 @@ public:
     return hypotf(
       goal_coordinates.x - node_coords.x,
       goal_coordinates.y - node_coords.y) * neutral_cost;
+  }
+
+  /**
+   * @brief Retrieve all valid neighbors of a node.
+   * @param node Pointer to the node we are currently exploring in A*
+   * @param graph Reference to graph to discover new nodes 
+   * @param neighbors Vector of neighbors to be filled
+   */
+  static inline void getNeighbors(
+    NodePtr & node,
+    std::function<bool(const unsigned int&, smac_planner::NodeSE2*&)> & validity_checker,
+    NodeVector & neighbors)
+  {
+    // NOTE(stevemacenski): Irritatingly, the order here matters. If you start in free
+    // space and then expand 8-connected, the first set of neighbors will be all cost
+    // _neutral_cost. Then its expansion will all be 2 * _neutral_cost but now multiple
+    // nodes are touching that node so the last cell to update the back pointer wins.
+    // Thusly, the ordering ends with the cardinal directions for both sets such that
+    // behavior is consistent in large free spaces between them.
+    // 100  50   0
+    // 100  50  50
+    // 100 100 100   where lower-middle '100' is visited with same cost by both bottom '50' nodes
+    // Therefore, it is valuable to have some low-potential across the entire map
+    // rather than a small inflation around the obstacles
+
+    //TODO STEVE implement get neighbors by motion models
+    int index;
+    NodePtr neighbor;
+    int node_i = node->getIndex();
+
+    // for(unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
+    //   index = node_i + _neighbors_grid_offsets[i];
+    //   if (index > 0 && validity_checker(index, neighbor))
+    //   {
+    //     neighbors.push_back(neighbor);
+    //   }
+    // }
   }
 
   NodeSE2 * parent;

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -30,17 +30,19 @@ namespace smac_planner
     // doesnt matter as much for 2D planner, but really will matter here
     // might speed things up a bit. Reserve graph (full, 20%, whatever) but dont fill in.
 
+// TODO make Node3D for XYZ search (3D nav)
+
 /**
- * @class smac_planner::Node3D
- * @brief Node3D implementation for graph
+ * @class smac_planner::NodeSE2
+ * @brief NodeSE2 implementation for graph
  */
-class Node3D
+class NodeSE2
 {
 public:
 
   /**
-   * @class smac_planner::Node3D::Coordinates
-   * @brief Node3D implementation of coordinate structure
+   * @class smac_planner::NodeSE2::Coordinates
+   * @brief NodeSE2 implementation of coordinate structure
    */
   struct Coordinates
   {
@@ -53,11 +55,11 @@ public:
   };
 
   /**
-   * @brief A constructor for smac_planner::Node3D
+   * @brief A constructor for smac_planner::NodeSE2
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  explicit Node3D(unsigned char & cost_in, const unsigned int index)
+  explicit NodeSE2(unsigned char & cost_in, const unsigned int index)
   : parent(nullptr),
     _cell_cost(static_cast<float>(cost_in)),
     _accumulated_cost(std::numeric_limits<float>::max()),
@@ -71,21 +73,47 @@ public:
   }
 
   /**
-   * @brief A destructor for smac_planner::Node3D
+   * @brief A destructor for smac_planner::NodeSE2
    */
-  ~Node3D()
+  ~NodeSE2()
   {
     parent = nullptr;
   }
 
   /**
    * @brief operator== for comparisons
-   * @param Node3D right hand side node reference
+   * @param NodeSE2 right hand side node reference
    * @return If cell indicies are equal
    */
-  bool operator==(const Node3D & rhs)
+  bool operator==(const NodeSE2 & rhs)
   {
     return this->_index == rhs._index;
+  }
+
+  /**
+   * @brief setting continuous coordinate search poses (in partial-cells)
+   * @param X X component of pose
+   * @param Y Y component of pose
+   * @param theta theta component of pose
+   */
+  inline void setPose(const float & x, const float & y, const float & theta)
+  {
+    _x = x;
+    _y = y;
+    _theta = theta;
+  }
+
+  /**
+   * @brief getting continuous coordinate search poses (in partial-cells)
+   * @param X X component of pose
+   * @param Y Y component of pose
+   * @param theta theta component of pose
+   */
+  inline void getPose(float & x, float & y, float & theta)
+  {
+    x = _x;
+    y = _y;
+    theta = _theta;
   }
 
   /**
@@ -93,7 +121,7 @@ public:
    * @param cost_in The costmap cost at this node
    * @param index The index of this node for self-reference
    */
-  void reset(const unsigned char & cost, const unsigned int index)
+  inline void reset(const unsigned char & cost, const unsigned int index)
   {
     parent = nullptr;
     _cell_cost = static_cast<float>(cost);
@@ -107,7 +135,7 @@ public:
    * @brief Gets the accumulated cost at this node
    * @return accumulated cost
    */
-  float & getAccumulatedCost()
+  inline float & getAccumulatedCost()
   {
     return _accumulated_cost;
   }
@@ -116,7 +144,7 @@ public:
    * @brief Sets the accumulated cost at this node
    * @param reference to accumulated cost
    */
-  void setAccumulatedCost(const float cost_in)
+  inline void setAccumulatedCost(const float cost_in)
   {
     _accumulated_cost = cost_in;
   }
@@ -125,7 +153,7 @@ public:
    * @brief Gets the costmap cost at this node
    * @return costmap cost
    */
-  float & getCost()
+  inline float & getCost()
   {
     return _cell_cost;
   }
@@ -134,7 +162,7 @@ public:
    * @brief Gets if cell has been visited in search
    * @param If cell was visited
    */
-  bool & wasVisited()
+  inline bool & wasVisited()
   {
     return _was_visited;
   }
@@ -142,7 +170,7 @@ public:
   /**
    * @brief Sets if cell has been visited in search
    */
-  void visited()
+  inline void visited()
   {
     _was_visited = true;
     _is_queued = false;
@@ -152,7 +180,7 @@ public:
    * @brief Gets if cell is currently queued in search
    * @param If cell was queued
    */
-  bool & isQueued()
+  inline bool & isQueued()
   {
     return _is_queued;
   }
@@ -160,7 +188,7 @@ public:
   /**
    * @brief Sets if cell is currently queued in search
    */
-  void queued()
+  inline void queued()
   {
     _is_queued = true;
   }
@@ -169,7 +197,7 @@ public:
    * @brief Gets cell index
    * @return Reference to cell index
    */
-  unsigned int & getIndex()
+  inline unsigned int & getIndex()
   {
     return _index;
   }
@@ -179,7 +207,7 @@ public:
    * @param traverse_unknown If we can explore unknown nodes on the graph
    * @return whether this node is valid and collision free
    */
-  bool isNodeValid(const bool & traverse_unknown) {
+  inline bool isNodeValid(const bool & traverse_unknown) {
     // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
     // the regular grid (e.g. your node is on the edge of the costmap and i+1
     // goes to the other side). This check would add compute time and my assertion is
@@ -235,7 +263,7 @@ public:
    * @param node Node index of new
    * @return Heuristic cost between the nodes
    */
-  static float getHeuristicCost(
+  static inline float getHeuristicCost(
     const Coordinates & node_coords,
     const Coordinates & goal_coordinates,
     const float & neutral_cost)
@@ -246,7 +274,7 @@ public:
       goal_coordinates.y - node_coords.y) * neutral_cost;
   }
 
-  Node3D * parent;
+  NodeSE2 * parent;
 
 private:
   float _cell_cost; // TODO temporary, to be repalced with pointer to collision detector

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -57,10 +57,12 @@ struct MotionTable
 
   void initDubin(
     unsigned int & size_x_in,
-    unsigned int & angle_quantization_in);
+    unsigned int & angle_quantization_in,
+    float & min_turning_radius);
   void initReedsShepp(
     unsigned int & size_x_in,
-    unsigned int & angle_quantization_in);
+    unsigned int & angle_quantization_in,
+    float & min_turning_radius);
   void initBalkcomMason(
     unsigned int & size_x_in,
     unsigned int & angle_quantization_in);
@@ -70,7 +72,7 @@ struct MotionTable
   
   std::vector<Pose> projections;
   unsigned int size_x;
-  unsigned int angle_quantization;
+  unsigned int num_angle_quantization;
 };
 
 /**
@@ -243,7 +245,8 @@ public:
   static void initMotionModel(
     const MotionModel & motion_model,
     unsigned int & size_x,
-    unsigned int & angle_quantization);
+    unsigned int & angle_quantization,
+    float min_turning_radius);
 
   /**
    * @brief Retrieve all valid neighbors of a node.

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -70,6 +70,8 @@ struct MotionTable
   MotionPoses projections;
   unsigned int size_x;
   unsigned int num_angle_quantization;
+  float num_angle_quantization_float;
+  float bin_size;
 };
 
 /**
@@ -92,30 +94,6 @@ public:
     Coordinates(const float & x_in, const float & y_in, const float & theta_in)
     : x(x_in), y(y_in), theta(theta_in)
     {};
-
-  /**
-   * @brief operator+ for addition
-   * @param MotionPose right hand side reference
-   * @return Added MotionPose and Coordinate
-   */
-    MotionPose operator+(const MotionPose & motion_model)
-    {
-      // TODO transform delta X, Y, and Theta into local coordinates
-      const float cos_theta = cos(theta);
-      const float sin_theta = sin(theta);
-      const float delta_x = motion_model._x * cos_theta - motion_model._y * sin_theta;
-      const float delta_y = motion_model._x * sin_theta + motion_model._y * cos_theta;
-      float new_heading = theta + motion_model._theta;
-
-      // TODO normalize theta - by number of bins
-      if (new_heading >= 72.0) {
-        new_heading -= 72.0;
-      } else if (new_heading < 0.0) {
-        new_heading += 72.0;
-      }
-
-      return MotionPose(delta_x + x, delta_y + y, new_heading);
-    }
 
     float x, y, theta;
   };

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -48,9 +48,9 @@ typedef std::vector<MotionPose> MotionPoses;
 // Must forward declare
 class NodeSE2;
 
-struct MotionTable 
+struct MotionTable
 {
-  MotionTable() {};
+  MotionTable() {}
 
   void initDubin(
     unsigned int & size_x_in,
@@ -66,7 +66,7 @@ struct MotionTable
 
   MotionPoses getProjections(NodeSE2 * & node);
   MotionPose getProjection(NodeSE2 * & node, const unsigned int & motion_index);
-  
+
   MotionPoses projections;
   unsigned int size_x;
   unsigned int num_angle_quantization;
@@ -90,10 +90,10 @@ public:
    */
   struct Coordinates
   {
-    Coordinates() {};
+    Coordinates() {}
     Coordinates(const float & x_in, const float & y_in, const float & theta_in)
     : x(x_in), y(y_in), theta(theta_in)
-    {};
+    {}
 
     float x, y, theta;
   };
@@ -228,9 +228,9 @@ public:
     const unsigned int & width, const unsigned int angle_quantization)
   {
     return Coordinates(
-        (index / angle_quantization) % width,  // x
-        index / (angle_quantization * width),  // y
-        index % angle_quantization);  // theta
+      (index / angle_quantization) % width,    // x
+      index / (angle_quantization * width),    // y
+      index % angle_quantization);    // theta
   }
 
   /**
@@ -252,12 +252,12 @@ public:
   /**
    * @brief Retrieve all valid neighbors of a node.
    * @param node Pointer to the node we are currently exploring in A*
-   * @param validity_checker Functor for state validity checking 
+   * @param validity_checker Functor for state validity checking
    * @param neighbors Vector of neighbors to be filled
    */
   static void getNeighbors(
     NodePtr & node,
-    std::function<bool(const unsigned int&, smac_planner::NodeSE2*&)> & validity_checker,
+    std::function<bool(const unsigned int &, smac_planner::NodeSE2 * &)> & validity_checker,
     NodeVector & neighbors);
 
   NodeSE2 * parent;

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -55,7 +55,7 @@ struct MotionTable
 {
   MotionTable() {};
 
-  void initDublin(
+  void initDubin(
     unsigned int & size_x_in,
     unsigned int & angle_quantization_in);
   void initReedsShepp(

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -60,9 +60,9 @@ struct MotionTable
     unsigned int & size_x_in,
     unsigned int & angle_quantization_in,
     float & min_turning_radius);
-  void initBalkcomMason(
-    unsigned int & size_x_in,
-    unsigned int & angle_quantization_in);
+  // void initBalkcomMason(
+  //   unsigned int & size_x_in,
+  //   unsigned int & angle_quantization_in);
 
   MotionPoses getProjections(NodeSE2 * & node);
   MotionPose getProjection(NodeSE2 * & node, const unsigned int & motion_index);

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -17,6 +17,7 @@
 
 #include <math.h>
 #include <vector>
+#include <cmath>
 #include <iostream>
 #include <functional>
 #include <queue>
@@ -33,14 +34,9 @@ namespace smac_planner
 struct MotionPose
 {
   MotionPose() {}
-  MotionPose(const float x, const float y, const float theta)
+  MotionPose(const float & x, const float & y, const float & theta)
   : _x(x), _y(y), _theta(theta)
   {}
-
-  MotionPose operator+(const MotionPose & rhs)
-  {
-    return MotionPose(rhs._x + _x, rhs._y + _y, rhs._theta + _theta);
-  }
 
   float _x;
   float _y;
@@ -102,9 +98,23 @@ public:
    * @param MotionPose right hand side reference
    * @return Added MotionPose and Coordinate
    */
-    MotionPose operator+(const MotionPose & rhs)
+    MotionPose operator+(const MotionPose & motion_model)
     {
-      return MotionPose(rhs._x + x, rhs._y + y, rhs._theta + theta);
+      // TODO transform delta X, Y, and Theta into local coordinates
+      const float cos_theta = cos(theta);
+      const float sin_theta = sin(theta);
+      const float delta_x = motion_model._x * cos_theta - motion_model._y * sin_theta;
+      const float delta_y = motion_model._x * sin_theta + motion_model._y * cos_theta;
+      float new_heading = theta + motion_model._theta;
+
+      // TODO normalize theta - by number of bins
+      if (new_heading >= 72.0) {
+        new_heading -= 72.0;
+      } else if (new_heading < 0.0) {
+        new_heading += 72.0;
+      }
+
+      return MotionPose(delta_x + x, delta_y + y, new_heading);
     }
 
     float x, y, theta;

--- a/smac_planner/include/smac_planner/options.hpp
+++ b/smac_planner/include/smac_planner/options.hpp
@@ -101,7 +101,7 @@ struct SmootherParams
  * @struct smac_planner::OptimizerParams
  * @brief Parameters for the ceres optimizer
  */
-struct OptimizerParams    
+struct OptimizerParams
 {
   OptimizerParams()
   : debug(false),
@@ -138,33 +138,38 @@ struct OptimizerParams
      */
     void get(rclcpp_lifecycle::LifecycleNode * node, const std::string & name)
     {
-    std::string local_name = name + std::string(".smoother.optimizer.advanced.");
+      std::string local_name = name + std::string(".smoother.optimizer.advanced.");
 
       // Optimizer advanced params
       nav2_util::declare_parameter_if_not_declared(
         node, local_name + "min_line_search_step_size",
         rclcpp::ParameterValue(1e-20));
-      node->get_parameter(local_name + "min_line_search_step_size",
+      node->get_parameter(
+        local_name + "min_line_search_step_size",
         min_line_search_step_size);
       nav2_util::declare_parameter_if_not_declared(
         node, local_name + "max_num_line_search_step_size_iterations",
         rclcpp::ParameterValue(50));
-      node->get_parameter(local_name + "max_num_line_search_step_size_iterations",
+      node->get_parameter(
+        local_name + "max_num_line_search_step_size_iterations",
         max_num_line_search_step_size_iterations);
       nav2_util::declare_parameter_if_not_declared(
         node, local_name + "line_search_sufficient_function_decrease",
         rclcpp::ParameterValue(1e-20));
-      node->get_parameter(local_name + "line_search_sufficient_function_decrease",
+      node->get_parameter(
+        local_name + "line_search_sufficient_function_decrease",
         line_search_sufficient_function_decrease);
       nav2_util::declare_parameter_if_not_declared(
         node, local_name + "max_num_line_search_direction_restarts",
         rclcpp::ParameterValue(10));
-      node->get_parameter(local_name + "max_num_line_search_direction_restarts",
+      node->get_parameter(
+        local_name + "max_num_line_search_direction_restarts",
         max_num_line_search_direction_restarts);
       nav2_util::declare_parameter_if_not_declared(
         node, local_name + "max_line_search_step_expansion",
         rclcpp::ParameterValue(50));
-      node->get_parameter(local_name + "max_line_search_step_expansion",
+      node->get_parameter(
+        local_name + "max_line_search_step_expansion",
         max_line_search_step_expansion);
     }
 

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -27,6 +27,7 @@
 #include "nav2_core/global_planner.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_util/node_utils.hpp"

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -119,7 +119,7 @@ protected:
   std::string _global_frame, _name;
   float _tolerance;
   int _downsampling_factor;
-  int _angle_quantizations;
+  unsigned int _angle_quantizations;
   double _angle_bin_size;
   bool _downsample_costmap;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -97,6 +97,13 @@ public:
     const float & mx, const float & my, const nav2_costmap_2d::Costmap2D * costmap);
 
   /**
+   * @brief Create quaternion from A* coord bins
+   * @param theta continuous bin coordinates angle
+   * @return quaternion orientation in map frame
+   */
+  geometry_msgs::msg::Quaternion getWorldOrientation(const float & theta);
+
+  /**
    * @brief Remove hooking at end of paths
    * @param path Path to remove hooking from
    */

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -30,6 +30,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_util/node_utils.hpp"
+#include "tf2/utils.h"
 
 namespace smac_planner
 {
@@ -85,13 +86,23 @@ public:
     const geometry_msgs::msg::PoseStamped & goal) override;
 
   /**
+   * @brief Create an Eigen Vector2D of world poses from continuous map coords
+   * @param mx float of map X coordinate
+   * @param my float of map Y coordinate
+   * @param costmap Costmap pointer
+   * @return Eigen::Vector2d eigen vector of the generated path
+   */
+  Eigen::Vector2d getWorldCoords(
+    const float & mx, const float & my, const nav2_costmap_2d::Costmap2D * costmap);
+
+  /**
    * @brief Remove hooking at end of paths
    * @param path Path to remove hooking from
    */
   void removeHook(std::vector<Eigen::Vector2d> & path);
 
 protected:
-  std::unique_ptr<AStarAlgorithm<Node2D>> _a_star;
+  std::unique_ptr<AStarAlgorithm<NodeSE2>> _a_star;
   std::unique_ptr<Smoother> _smoother;
   std::unique_ptr<Upsampler> _upsampler;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
@@ -100,11 +111,11 @@ protected:
   std::string _global_frame, _name;
   float _tolerance;
   int _downsampling_factor;
+  int _angle_quantizations;
+  double _angle_bin_size;
   bool _downsample_costmap;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
-  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug1_pub;
-  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug2_pub;
-  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoother_debug3_pub;
+  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoothed_plan_publisher;
   SmootherParams _smoother_params;
   OptimizerParams _optimizer_params;
   int _upsampling_ratio;

--- a/smac_planner/include/smac_planner/smac_planner.hpp
+++ b/smac_planner/include/smac_planner/smac_planner.hpp
@@ -91,7 +91,7 @@ public:
   void removeHook(std::vector<Eigen::Vector2d> & path);
 
 protected:
-  std::unique_ptr<AStarAlgorithm<Node>> _a_star;
+  std::unique_ptr<AStarAlgorithm<Node2D>> _a_star;
   std::unique_ptr<Smoother> _smoother;
   std::unique_ptr<Upsampler> _upsampler;
   std::unique_ptr<CostmapDownsampler> _costmap_downsampler;

--- a/smac_planner/include/smac_planner/smac_planner_2d.hpp
+++ b/smac_planner/include/smac_planner/smac_planner_2d.hpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#ifndef SMAC_PLANNER__SMAC_PLANNER_2D_HPP_
+#define SMAC_PLANNER__SMAC_PLANNER_2D_HPP_
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "smac_planner/a_star.hpp"
+#include "smac_planner/smoother.hpp"
+#include "smac_planner/upsampler.hpp"
+#include "smac_planner/costmap_downsampler.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "nav2_core/global_planner.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/node_utils.hpp"
+#include "tf2/utils.h"
+
+namespace smac_planner
+{
+
+class SmacPlanner2D : public nav2_core::GlobalPlanner
+{
+public:
+  /**
+   * @brief constructor
+   */
+  SmacPlanner2D();
+
+  /**
+   * @brief destructor
+   */
+  ~SmacPlanner2D();
+
+  /**
+   * @brief Configuring plugin
+   * @param parent Lifecycle node pointer
+   * @param name Name of plugin map
+   * @param tf Shared ptr of TF2 buffer
+   * @param costmap_ros Costmap2DROS object
+   */
+  void configure(
+    rclcpp_lifecycle::LifecycleNode::SharedPtr parent,
+    std::string name, std::shared_ptr<tf2_ros::Buffer> tf,
+    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros) override;
+
+  /**
+   * @brief Cleanup lifecycle node
+   */
+  void cleanup() override;
+
+  /**
+   * @brief Activate lifecycle node
+   */
+  void activate() override;
+
+  /**
+   * @brief Deactivate lifecycle node
+   */
+  void deactivate() override;
+
+  /**
+   * @brief Creating a plan from start and goal poses
+   * @param start Start pose
+   * @param goal Goal pose
+   * @return nav2_msgs::Path of the generated path
+   */
+  nav_msgs::msg::Path createPlan(
+    const geometry_msgs::msg::PoseStamped & start,
+    const geometry_msgs::msg::PoseStamped & goal) override;
+
+  /**
+   * @brief Create an Eigen Vector2D of world poses from continuous map coords
+   * @param mx float of map X coordinate
+   * @param my float of map Y coordinate
+   * @param costmap Costmap pointer
+   * @return Eigen::Vector2d eigen vector of the generated path
+   */
+  Eigen::Vector2d getWorldCoords(
+    const float & mx, const float & my, const nav2_costmap_2d::Costmap2D * costmap);
+
+  /**
+   * @brief Remove hooking at end of paths
+   * @param path Path to remove hooking from
+   */
+  void removeHook(std::vector<Eigen::Vector2d> & path);
+
+protected:
+  std::unique_ptr<AStarAlgorithm<Node2D>> _a_star;
+  std::unique_ptr<Smoother> _smoother;
+  std::unique_ptr<Upsampler> _upsampler;
+  std::unique_ptr<CostmapDownsampler> _costmap_downsampler;
+  nav2_util::LifecycleNode::SharedPtr _node;
+  nav2_costmap_2d::Costmap2D * _costmap;
+  std::string _global_frame, _name;
+  float _tolerance;
+  int _downsampling_factor;
+  bool _downsample_costmap;
+  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _raw_plan_publisher;
+  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr _smoothed_plan_publisher;
+  SmootherParams _smoother_params;
+  OptimizerParams _optimizer_params;
+  int _upsampling_ratio;
+};
+
+}  // namespace smac_planner
+
+#endif  // SMAC_PLANNER__SMAC_PLANNER_2D_HPP_

--- a/smac_planner/include/smac_planner/smoother.hpp
+++ b/smac_planner/include/smac_planner/smoother.hpp
@@ -51,7 +51,8 @@ public:
   /**
    * @brief Initialization of the smoother
    */
-  void initialize(const OptimizerParams params) {
+  void initialize(const OptimizerParams params)
+  {
     _debug = params.debug;
 
     // General Params
@@ -107,7 +108,7 @@ public:
     }
 
     ceres::GradientProblemSolver::Summary summary;
-    ceres::GradientProblem problem(new UnconstrainedSmootherCostFunction(& path, costmap, params));
+    ceres::GradientProblem problem(new UnconstrainedSmootherCostFunction(&path, costmap, params));
     ceres::Solve(_options, problem, parameters, &summary);
 
     if (_debug) {

--- a/smac_planner/include/smac_planner/types.hpp
+++ b/smac_planner/include/smac_planner/types.hpp
@@ -21,8 +21,6 @@
 namespace smac_planner
 {
 
-typedef std::vector<std::pair<float, float>> IndexPath;
-
 typedef std::pair<float, unsigned int> NodeHeuristicPair;
 
 }  // namespace smac_planner

--- a/smac_planner/include/smac_planner/types.hpp
+++ b/smac_planner/include/smac_planner/types.hpp
@@ -21,7 +21,7 @@
 namespace smac_planner
 {
 
-typedef std::vector<unsigned int> IndexPath;
+typedef std::vector<std::pair<float, float>> IndexPath;
 
 typedef std::pair<float, unsigned int> NodeHeuristicPair;
 

--- a/smac_planner/include/smac_planner/types.hpp
+++ b/smac_planner/include/smac_planner/types.hpp
@@ -16,14 +16,14 @@
 #define SMAC_PLANNER__TYPES_HPP_
 
 #include <vector>
+#include <utility>
 
 namespace smac_planner
 {
+
 typedef std::vector<unsigned int> IndexPath;
 
-typedef std::pair<float, float> Coordinates;
-
-typedef std::pair<double, double> DoubleCoordinates;
+typedef std::pair<float, unsigned int> NodeHeuristicPair;
 
 }  // namespace smac_planner
 

--- a/smac_planner/include/smac_planner/upsampler.hpp
+++ b/smac_planner/include/smac_planner/upsampler.hpp
@@ -56,7 +56,8 @@ public:
   /**
    * @brief Initialization of the Upsampler
    */
-  void initialize(const OptimizerParams params) {
+  void initialize(const OptimizerParams params)
+  {
     _debug = params.debug;
 
     // General Params
@@ -77,7 +78,8 @@ public:
     _options.min_line_search_step_size = params.advanced.min_line_search_step_size;//1e-30;
     _options.max_num_line_search_step_size_iterations =
       params.advanced.max_num_line_search_step_size_iterations;
-    _options.line_search_sufficient_function_decrease = params.advanced.line_search_sufficient_function_decrease;//1e-30;
+    _options.line_search_sufficient_function_decrease =
+      params.advanced.line_search_sufficient_function_decrease;                                                  //1e-30;
     _options.max_line_search_step_contraction = params.advanced.max_line_search_step_contraction;
     _options.min_line_search_step_contraction = params.advanced.min_line_search_step_contraction;
     _options.max_num_line_search_direction_restarts =
@@ -129,7 +131,7 @@ public:
       temp_path.push_back(path[pt]);
 
       parameters[param_ratio * pt + 2] = interpolated[0];
-      parameters[param_ratio * pt + 3] = interpolated[1];  
+      parameters[param_ratio * pt + 3] = interpolated[1];
       temp_path.push_back(interpolated);
     }
 
@@ -152,11 +154,11 @@ public:
     // 10-15 hz, regularly
     // std::vector<Eigen::Vector2d> path_double_sampled;
     // for (int i = 0; i != path.size() - 1; i++) {  // last term should not be upsampled
-    //   path_double_sampled.push_back(path[i]); 
+    //   path_double_sampled.push_back(path[i]);
     //   path_double_sampled.push_back((path[i+1] + path[i]) / 2);
     // }
 
-    // std::unique_ptr<ceres::Problem> problem = std::make_unique<ceres::Problem>(); 
+    // std::unique_ptr<ceres::Problem> problem = std::make_unique<ceres::Problem>();
     // for (uint i = 1; i != path_double_sampled.size() - 1; i++) {
     //   ceres::CostFunction * cost_fn = new UpsamplerConstrainedCostFunction(path_double_sampled, params, 2, i);
     //   problem->AddResidualBlock(cost_fn, nullptr, &path_double_sampled[i][0], &path_double_sampled[i][1]);
@@ -170,11 +172,11 @@ public:
     // if (upsample_ratio == 4) {
     //   std::vector<Eigen::Vector2d> path_quad_sampled;
     //   for (int i = 0; i != path_double_sampled.size() - 1; i++) {
-    //     path_quad_sampled.push_back(path_double_sampled[i]); 
+    //     path_quad_sampled.push_back(path_double_sampled[i]);
     //     path_quad_sampled.push_back((path_double_sampled[i+1] + path_double_sampled[i]) / 2.0);
     //   }
 
-    //   std::unique_ptr<ceres::Problem> problem2 = std::make_unique<ceres::Problem>(); 
+    //   std::unique_ptr<ceres::Problem> problem2 = std::make_unique<ceres::Problem>();
     //   for (uint i = 1; i != path_quad_sampled.size() - 1; i++) {
     //     ceres::CostFunction * cost_fn = new UpsamplerConstrainedCostFunction(path_quad_sampled, params, 4, i);
     //     problem2->AddResidualBlock(cost_fn, nullptr, &path_quad_sampled[i][0], &path_quad_sampled[i][1]);

--- a/smac_planner/include/smac_planner/upsampler_cost_function_nlls.hpp
+++ b/smac_planner/include/smac_planner/upsampler_cost_function_nlls.hpp
@@ -29,7 +29,7 @@
 #include "smac_planner/minimal_costmap.hpp"
 #include "smac_planner/options.hpp"
 
-#define EPSILON 0.0001  
+#define EPSILON 0.0001
 
 namespace smac_planner
 {
@@ -45,7 +45,7 @@ namespace smac_planner
  * @brief Cost function for path upsampling with multiple terms using NLLS
  * including curvature, smoothness, collision, and avoid obstacles.
  */
-class UpsamplerConstrainedCostFunction : public ceres::SizedCostFunction<1, 1, 1> 
+class UpsamplerConstrainedCostFunction : public ceres::SizedCostFunction<1, 1, 1>
 {
 public:
   /**
@@ -68,12 +68,13 @@ public:
    * @struct CurvatureComputations
    * @brief Cache common computations between the curvature terms to minimize recomputations
    */
-  struct CurvatureComputations 
+  struct CurvatureComputations
   {
     /**
      * @brief A constructor for smac_planner::CurvatureComputations
      */
-    CurvatureComputations() {
+    CurvatureComputations()
+    {
       valid = true;
     }
 
@@ -82,12 +83,13 @@ public:
      * @brief Check if result is valid for penalty
      * @return is valid (non-nan, non-inf, and turning angle > max)
      */
-    bool isValid() {
+    bool isValid()
+    {
       return valid;
     }
 
-    Eigen::Vector2d delta_xi{0,0};
-    Eigen::Vector2d delta_xi_p{0,0};
+    Eigen::Vector2d delta_xi{0, 0};
+    Eigen::Vector2d delta_xi_p{0, 0};
     double delta_xi_norm{0};
     double delta_xi_p_norm{0};
     double delta_phi_i{0};
@@ -97,7 +99,7 @@ public:
 
   /**
    * @brief Smoother cost function evaluation
-   * @param parameters X,Y pairs of points 
+   * @param parameters X,Y pairs of points
    * @param cost total cost of path
    * @param gradient of path at each X,Y pair from cost function derived analytically
    * @return if successful in computing values
@@ -153,12 +155,12 @@ protected:
     double & r) const
   {
     r += weight * (
-      pt_p.dot(pt_p)
-      - 4 * pt_p.dot(pt)
-      + 2 * pt_p.dot(pt_m)
-      + 4 * pt.dot(pt)
-      - 4 * pt.dot(pt_m)
-      + pt_m.dot(pt_m));  // objective function value
+      pt_p.dot(pt_p) -
+      4 * pt_p.dot(pt) +
+      2 * pt_p.dot(pt_m) +
+      4 * pt.dot(pt) -
+      4 * pt.dot(pt_m) +
+      pt_m.dot(pt_m));    // objective function value
   }
 
   /**
@@ -179,9 +181,9 @@ protected:
     double & j1) const
   {
     j0 += weight *
-      (- 4 * pt_m[0] + 8 * pt[0] - 4 * pt_p[0]);  // xi x component of partial-derivative
+      (-4 * pt_m[0] + 8 * pt[0] - 4 * pt_p[0]);   // xi x component of partial-derivative
     j1 += weight *
-      (- 4 * pt_m[1] + 8 * pt[1] - 4 * pt_p[1]);  // xi y component of partial-derivative
+      (-4 * pt_m[1] + 8 * pt[1] - 4 * pt_p[1]);   // xi y component of partial-derivative
   }
 
   /**
@@ -199,13 +201,14 @@ protected:
   {
     curvature_params.valid = true;
     curvature_params.delta_xi = Eigen::Vector2d(pt[0] - pt_m[0], pt[1] - pt_m[1]);
-    curvature_params.delta_xi_p = Eigen::Vector2d(pt_p[0] - pt[0], pt_p[1] - pt[1]); 
+    curvature_params.delta_xi_p = Eigen::Vector2d(pt_p[0] - pt[0], pt_p[1] - pt[1]);
     curvature_params.delta_xi_norm = curvature_params.delta_xi.norm();
     curvature_params.delta_xi_p_norm = curvature_params.delta_xi_p.norm();
 
     if (curvature_params.delta_xi_norm < EPSILON || curvature_params.delta_xi_p_norm < EPSILON ||
       std::isnan(curvature_params.delta_xi_p_norm) || std::isnan(curvature_params.delta_xi_norm) ||
-      std::isinf(curvature_params.delta_xi_p_norm) || std::isinf(curvature_params.delta_xi_norm)) {
+      std::isinf(curvature_params.delta_xi_p_norm) || std::isinf(curvature_params.delta_xi_norm))
+    {
       // ensure we have non-nan values returned
       curvature_params.valid = false;
       return;
@@ -222,12 +225,13 @@ protected:
     curvature_params.delta_phi_i = std::acos(projection);
     curvature_params.turning_rad = curvature_params.delta_phi_i / curvature_params.delta_xi_norm;
 
-    curvature_params.ki_minus_kmax = curvature_params.turning_rad - _upsample_ratio * _params.max_curvature;
+    curvature_params.ki_minus_kmax = curvature_params.turning_rad - _upsample_ratio *
+      _params.max_curvature;
     // TODO is use of upsample_ratio correct here? small number?
     // TODO can remove the subtraction with a lower weight value, does have direction issue, maybe just tuning?
 
     if (curvature_params.ki_minus_kmax <= EPSILON) {
-      // Quadratic penalty need not apply  
+      // Quadratic penalty need not apply
       curvature_params.valid = false;
     }
   }
@@ -251,7 +255,7 @@ protected:
   {
     getCurvatureParams(pt, pt_p, pt_m, curvature_params);
 
-    if (!curvature_params.isValid()) { 
+    if (!curvature_params.isValid()) {
       return;
     }
 
@@ -296,10 +300,13 @@ protected:
       (1 / curvature_params.delta_xi_norm) * partial_delta_phi_i_wrt_cost_delta_phi_i;
     const double & common_suffix = curvature_params.delta_phi_i /
       (curvature_params.delta_xi_norm * curvature_params.delta_xi_norm);
-    const Eigen::Vector2d & d_delta_xi_d_xi = curvature_params.delta_xi / curvature_params.delta_xi_norm;
+    const Eigen::Vector2d & d_delta_xi_d_xi = curvature_params.delta_xi /
+      curvature_params.delta_xi_norm;
 
-    const Eigen::Vector2d jacobian =  u * (common_prefix * (-p1 - p2) - (common_suffix * d_delta_xi_d_xi));
-    const Eigen::Vector2d jacobian_im1 = u * (common_prefix * p2 + (common_suffix * d_delta_xi_d_xi));
+    const Eigen::Vector2d jacobian = u *
+      (common_prefix * (-p1 - p2) - (common_suffix * d_delta_xi_d_xi));
+    const Eigen::Vector2d jacobian_im1 = u *
+      (common_prefix * p2 + (common_suffix * d_delta_xi_d_xi));
     const Eigen::Vector2d jacobian_ip1 = u * (common_prefix * p1);
     // j0 += weight * jacobian[0]; // TODO try with the prior xi-1 and xi+1s
     // j1 += weight * jacobian[1];

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -274,8 +274,7 @@ bool AStarAlgorithm<NodeT>::createPath(CoordinateVector & path, int & iterations
       }
 
       neighbor = & _graph->operator[](index);
-      if (neighbor->isNodeValid(_traverse_unknown))
-      {
+      if (neighbor->isNodeValid(_traverse_unknown)) {
         return true;
       }
 
@@ -430,7 +429,8 @@ float AStarAlgorithm<NodeT>::getTraversalCost(
 template<typename NodeT>
 float AStarAlgorithm<NodeT>::getHeuristicCost(const NodePtr & node)
 {
-  Coordinates node_coords = NodeT::getCoords(node->getIndex(), getSizeX(), getSizeDim3());
+  const Coordinates node_coords =
+    NodeT::getCoords(node->getIndex(), getSizeX(), getSizeDim3());
   float heuristic = NodeT::getHeuristicCost(
     node_coords, _goal_coordinates) * _neutral_cost;
   

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -176,7 +176,10 @@ void AStarAlgorithm<NodeSE2>::setStart(
 {
   unsigned int index = NodeSE2::getIndex(mx, my, theta, getSizeX(), getSizeDim3());
   _start = & _graph->operator[](index);
-  _start->setPose(Coordinates(mx, my, theta));
+  _start->setPose(Coordinates(
+    static_cast<float>(mx),
+    static_cast<float>(my),
+    static_cast<float>(theta)));
 }
 
 template <>
@@ -202,7 +205,10 @@ void AStarAlgorithm<NodeSE2>::setGoal(
 {
   unsigned int index = NodeSE2::getIndex(mx, my, theta, getSizeX(), getSizeDim3());
   _goal = & _graph->operator[](index);
-  _goal_coordinates = NodeSE2::Coordinates(mx, my, theta);
+  _goal_coordinates = NodeSE2::Coordinates(
+    static_cast<float>(mx),
+    static_cast<float>(my),
+    static_cast<float>(theta));
 }
 
 template<typename NodeT>
@@ -370,11 +376,8 @@ bool AStarAlgorithm<NodeSE2>::backtracePath(NodePtr & node, CoordinateVector & p
 
   NodePtr current_node = node;
 
-  // TODO(stevemacenski): return orientation (important?)
-  // TODO: deal with rotations in place should be a node or cull b/c no orientation info?
   while (current_node->parent) {
-    const Coordinates node_continuous_pose = current_node->pose;
-    path.push_back(node_continuous_pose);
+    path.push_back(current_node->pose);
     current_node = current_node->parent;
   }
 

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -332,7 +332,8 @@ bool AStarAlgorithm<NodeT>::createPath(CoordinateVector & path, int & iterations
         neighbor->parent = current_node;
 
         // 4.3) If not in queue or visited, add it
-        if (!neighbor->wasVisited()) {
+        // TODO(stevemacenski): should this always be true?
+        if (true /*!neighbor->wasVisited()*/) {
           neighbor->queued();
           addNode(g_cost + getHeuristicCost(neighbor), neighbor);
         }

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -114,7 +114,7 @@ void AStarAlgorithm<Node2D>::createGraph(
   }
 }
 
-// Population order theta, Y, X to match getIndex expected order
+// Population order theta, X, Y to match getIndex expected structure
 template <>
 void AStarAlgorithm<NodeSE2>::createGraph(
   const unsigned int & x,
@@ -132,24 +132,24 @@ void AStarAlgorithm<NodeSE2>::createGraph(
     _graph->clear();
     _graph->reserve(x * y * _dim3_size);
 
-    for (unsigned int i = 0; i != x; i++) {
-      for (unsigned int j = 0; j != y; j++) {
+    for (unsigned int j = 0; j != y; j++) {
+      for (unsigned int i = 0; i != x; i++) {
         for (unsigned int k = 0; k != _dim3_size; k++) {
           index = NodeSE2::getIndex(i, j, k, _x_size, _dim3_size);
           _graph->emplace_back(
-            costs[i * j],
+            costs[i + _x_size * j],
             index);
         }
       }
     }
   } else {
-    for (unsigned int i = 0; i != x; i++) {
-      for (unsigned int j = 0; j != y; j++) {
+    for (unsigned int j = 0; j != y; j++) {
+      for (unsigned int i = 0; i != x; i++) {
         for (unsigned int k = 0; k != _dim3_size; k++) {
           // Optimization: operator[] is used over at() for performance (no bound checking)
           index = NodeSE2::getIndex(i, j, k, _x_size, _dim3_size);
           _graph->operator[](index).reset(
-            costs[i * j],
+            costs[i + _x_size * j],
             index);
         }
       }

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -86,14 +86,14 @@ template <>
 void AStarAlgorithm<Node2D>::createGraph(
   const unsigned int & x_size,
   const unsigned int & y_size,
-  const unsigned int & theta_size,
+  const unsigned int & dim_3_size,
   unsigned char * & costs)
 {
-  if (theta_size != 1) {
-    throw std::runtime_error("Node type Node2D cannot be given non-1 angle quantization.");
+  if (dim_3_size != 1) {
+    throw std::runtime_error("Node type Node2D cannot be given non-1 dim 3 quantization.");
   }
 
-  _dim3_size = theta_size;  // 2D search MUST be 2D, not 3D or SE2.
+  _dim3_size = dim_3_size;  // 2D search MUST be 2D, not 3D or SE2.
 
   if (getSizeX() != x_size || getSizeY() != y_size) {
     _x_size = x_size;
@@ -112,15 +112,15 @@ void AStarAlgorithm<Node2D>::createGraph(
   }
 }
 
-// Population order theta, X, Y to match getIndex expected structure
+// Population order dim_3, X, Y to match getIndex expected structure
 template <>
 void AStarAlgorithm<NodeSE2>::createGraph(
   const unsigned int & x_size,
   const unsigned int & y_size,
-  const unsigned int & theta_size,
+  const unsigned int & dim_3_size,
   unsigned char * & costs)
 {
-  _dim3_size = theta_size;
+  _dim3_size = dim_3_size;
   unsigned int index;
 
   if (getSizeX() != x_size || getSizeY() != y_size) {
@@ -159,10 +159,10 @@ template <>
 void AStarAlgorithm<Node2D>::setStart(
   const unsigned int & mx,
   const unsigned int & my,
-  const unsigned int & theta)
+  const unsigned int & dim_3)
 {
-  if (theta != 0) {
-    throw std::runtime_error("Node type Node2D cannot be given non-zero starting angle.");
+  if (dim_3 != 0) {
+    throw std::runtime_error("Node type Node2D cannot be given non-zero starting dim 3.");
   }
   unsigned int index = Node2D::getIndex(mx, my, getSizeX());
   _start = & _graph->operator[](index);
@@ -172,24 +172,24 @@ template <>
 void AStarAlgorithm<NodeSE2>::setStart(
   const unsigned int & mx,
   const unsigned int & my,
-  const unsigned int & theta)
+  const unsigned int & dim_3)
 {
-  unsigned int index = NodeSE2::getIndex(mx, my, theta, getSizeX(), getSizeDim3());
+  unsigned int index = NodeSE2::getIndex(mx, my, dim_3, getSizeX(), getSizeDim3());
   _start = & _graph->operator[](index);
   _start->setPose(Coordinates(
     static_cast<float>(mx),
     static_cast<float>(my),
-    static_cast<float>(theta)));
+    static_cast<float>(dim_3)));
 }
 
 template <>
 void AStarAlgorithm<Node2D>::setGoal(
   const unsigned int & mx,
   const unsigned int & my,
-  const unsigned int & theta)
+  const unsigned int & dim_3)
 {
-  if (theta != 0) {
-    throw std::runtime_error("Node type Node2D cannot be given non-zero goal angle.");
+  if (dim_3 != 0) {
+    throw std::runtime_error("Node type Node2D cannot be given non-zero goal dim 3.");
   }
 
   unsigned int index = Node2D::getIndex(mx, my, getSizeX());
@@ -201,14 +201,14 @@ template <>
 void AStarAlgorithm<NodeSE2>::setGoal(
   const unsigned int & mx,
   const unsigned int & my,
-  const unsigned int & theta)
+  const unsigned int & dim_3)
 {
-  unsigned int index = NodeSE2::getIndex(mx, my, theta, getSizeX(), getSizeDim3());
+  unsigned int index = NodeSE2::getIndex(mx, my, dim_3, getSizeX(), getSizeDim3());
   _goal = & _graph->operator[](index);
   _goal_coordinates = NodeSE2::Coordinates(
     static_cast<float>(mx),
     static_cast<float>(my),
-    static_cast<float>(theta));
+    static_cast<float>(dim_3));
 }
 
 template<typename NodeT>

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -288,17 +288,17 @@ bool AStarAlgorithm<NodeT>::createPath(IndexPath & path, int & iterations, const
     if (isGoal(current_node)) {
       return backtracePath(current_node, path);
     }
-    else if (_best_heuristic_node.first < getToleranceHeuristic()) {
-      // Optimization: Let us find when in tolerance and refine within reason
-      approach_iterations++;
-      if (approach_iterations > getOnApproachMaxIterations() ||
-        iterations + 1 == getMaxIterations())
-      {
-        NodePtr node = & _graph->operator[](_best_heuristic_node.second);
-        return backtracePath(node, path);
-      }
-    }
-    // TODO STEVE removed for Hybrid testing
+    // else if (_best_heuristic_node.first < getToleranceHeuristic()) {
+    //   // Optimization: Let us find when in tolerance and refine within reason
+    //   approach_iterations++;
+    //   if (approach_iterations > getOnApproachMaxIterations() ||
+    //     iterations + 1 == getMaxIterations())
+    //   {
+    //     NodePtr node = & _graph->operator[](_best_heuristic_node.second);
+    //     return backtracePath(node, path);
+    //   }
+    // }
+    // TODO STEVE removed, causing issues in NodeSE2
 
     // 4) Expand neighbors of Nbest not visited
     neighbors.clear();

--- a/smac_planner/src/costmap_downsampler.cpp
+++ b/smac_planner/src/costmap_downsampler.cpp
@@ -31,19 +31,19 @@ CostmapDownsampler::~CostmapDownsampler()
 }
 
 void CostmapDownsampler::initialize(
-const std::string & global_frame,
-const std::string & topic_name,
-nav2_costmap_2d::Costmap2D * const costmap,
-const unsigned int & downsampling_factor)
+  const std::string & global_frame,
+  const std::string & topic_name,
+  nav2_costmap_2d::Costmap2D * const costmap,
+  const unsigned int & downsampling_factor)
 {
   _topic_name = topic_name;
   _costmap = costmap;
   _downsampling_factor = downsampling_factor;
   updateCostmapSize();
 
-  _downsampled_costmap = std::make_unique<nav2_costmap_2d::Costmap2D>
-    (_downsampled_size_x, _downsampled_size_y, _downsampled_resolution,
-     _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
+  _downsampled_costmap = std::make_unique<nav2_costmap_2d::Costmap2D>(
+    _downsampled_size_x, _downsampled_size_y, _downsampled_resolution,
+    _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
 
   _downsampled_costmap_pub = std::make_unique<nav2_costmap_2d::Costmap2DPublisher>(
     _node, _downsampled_costmap.get(), global_frame, _topic_name, false);
@@ -58,7 +58,8 @@ nav2_costmap_2d::Costmap2D * CostmapDownsampler::downsample(
   // Adjust costmap size if needed
   if (_downsampled_costmap->getSizeInCellsX() != _downsampled_size_x ||
     _downsampled_costmap->getSizeInCellsY() != _downsampled_size_y ||
-    _downsampled_costmap->getResolution() != _downsampled_resolution) {
+    _downsampled_costmap->getResolution() != _downsampled_resolution)
+  {
     resizeCostmap();
   }
 

--- a/smac_planner/src/costmap_downsampler.cpp
+++ b/smac_planner/src/costmap_downsampler.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2020, Carlos Luis
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include "smac_planner/costmap_downsampler.hpp"
+
+namespace smac_planner
+{
+
+CostmapDownsampler::CostmapDownsampler(const nav2_util::LifecycleNode::SharedPtr & node)
+: _costmap(nullptr),
+  _downsampled_costmap(nullptr),
+  _downsampled_costmap_pub(nullptr),
+  _node(node)
+{
+}
+
+CostmapDownsampler::~CostmapDownsampler()
+{
+}
+
+void CostmapDownsampler::initialize(
+const std::string & global_frame,
+const std::string & topic_name,
+nav2_costmap_2d::Costmap2D * const costmap,
+const unsigned int & downsampling_factor)
+{
+  _topic_name = topic_name;
+  _costmap = costmap;
+  _downsampling_factor = downsampling_factor;
+  updateCostmapSize();
+
+  _downsampled_costmap = std::make_unique<nav2_costmap_2d::Costmap2D>
+    (_downsampled_size_x, _downsampled_size_y, _downsampled_resolution,
+     _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
+
+  _downsampled_costmap_pub = std::make_unique<nav2_costmap_2d::Costmap2DPublisher>(
+    _node, _downsampled_costmap.get(), global_frame, _topic_name, false);
+}
+
+nav2_costmap_2d::Costmap2D * CostmapDownsampler::downsample(
+  const unsigned int & downsampling_factor)
+{
+  _downsampling_factor = downsampling_factor;
+  updateCostmapSize();
+
+  // Adjust costmap size if needed
+  if (_downsampled_costmap->getSizeInCellsX() != _downsampled_size_x ||
+    _downsampled_costmap->getSizeInCellsY() != _downsampled_size_y ||
+    _downsampled_costmap->getResolution() != _downsampled_resolution) {
+    resizeCostmap();
+  }
+
+  // Assign costs
+  for (int i = 0; i < _downsampled_size_x; ++i) {
+    for (int j = 0; j < _downsampled_size_y; ++j) {
+      setCostOfCell(i, j);
+    }
+  }
+
+  if (_node->count_subscribers(_topic_name) > 0) {
+    _downsampled_costmap_pub->publishCostmap();
+  }
+
+  return _downsampled_costmap.get();
+}
+
+void CostmapDownsampler::updateCostmapSize()
+{
+  _size_x = _costmap->getSizeInCellsX();
+  _size_y = _costmap->getSizeInCellsY();
+  _downsampled_size_x = ceil(static_cast<float>(_size_x) / _downsampling_factor);
+  _downsampled_size_y = ceil(static_cast<float>(_size_y) / _downsampling_factor);
+  _downsampled_resolution = _downsampling_factor * _costmap->getResolution();
+}
+
+void CostmapDownsampler::resizeCostmap()
+{
+  _downsampled_costmap->resizeMap(
+    _downsampled_size_x,
+    _downsampled_size_y,
+    _downsampled_resolution,
+    _costmap->getOriginX(),
+    _costmap->getOriginY());
+}
+
+void CostmapDownsampler::setCostOfCell(
+  const unsigned int & new_mx,
+  const unsigned int & new_my)
+{
+  unsigned int mx, my;
+  unsigned char cost = 0;
+  unsigned int x_offset = new_mx * _downsampling_factor;
+  unsigned int y_offset = new_my * _downsampling_factor;
+
+  for (int i = 0; i < _downsampling_factor; ++i) {
+    mx = x_offset + i;
+    if (mx >= _size_x) {
+      continue;
+    }
+    for (int j = 0; j < _downsampling_factor; ++j) {
+      my = y_offset + j;
+      if (my >= _size_y) {
+        continue;
+      }
+      cost = std::max(cost, _costmap->getCost(mx, my));
+    }
+  }
+
+  _downsampled_costmap->setCost(new_mx, new_my, cost);
+}
+
+}  // namespace smac_planner

--- a/smac_planner/src/node_2d.cpp
+++ b/smac_planner/src/node_2d.cpp
@@ -54,14 +54,15 @@ bool Node2D::isNodeValid(const bool & traverse_unknown) {
   // This is intentionally un-included to increase speed, but be aware. If this causes
   // trouble, please file a ticket and we can address it then.
 
-  // occupied node
   auto & cost = this->getCost();
+
+  // occupied node
   if (cost == OCCUPIED || cost == INSCRIBED) {
     return false;
   }
 
   // unknown node
-  if (cost == UNKNOWN && ! traverse_unknown) {
+  if (cost == UNKNOWN && !traverse_unknown) {
     return false;
   }
 
@@ -100,7 +101,7 @@ void Node2D::initNeighborhood(
 
 void Node2D::getNeighbors(
   NodePtr & node,
-  std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validity_checker,
+  std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validityCheckerFunctor,
   NodeVector & neighbors)
 {
   // NOTE(stevemacenski): Irritatingly, the order here matters. If you start in free
@@ -120,7 +121,7 @@ void Node2D::getNeighbors(
 
   for(unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
     index = node_i + _neighbors_grid_offsets[i];
-    if (index > 0 && validity_checker(index, neighbor))
+    if (validityCheckerFunctor(index, neighbor))
     {
       neighbors.push_back(neighbor);
     }

--- a/smac_planner/src/node_2d.cpp
+++ b/smac_planner/src/node_2d.cpp
@@ -45,7 +45,8 @@ void Node2D::reset(const unsigned char & cost, const unsigned int index)
   _is_queued = false;
 }
 
-bool Node2D::isNodeValid(const bool & traverse_unknown) {
+bool Node2D::isNodeValid(const bool & traverse_unknown)
+{
   // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
   // the regular grid (e.g. your node is on the edge of the costmap and i+1
   // goes to the other side). This check would add compute time and my assertion is
@@ -91,17 +92,18 @@ void Node2D::initNeighborhood(
       break;
     case MotionModel::MOORE:
       _neighbors_grid_offsets = {-1, +1, -x_size, +x_size, -x_size - 1,
-                                 -x_size + 1, +x_size - 1, +x_size + 1};
+        -x_size + 1, +x_size - 1, +x_size + 1};
       break;
     default:
-      throw std::runtime_error("Invalid neighborhood type selected. "
-        "Von-Neumann and Moore are valid for Node2D.");
+      throw std::runtime_error(
+              "Invalid neighborhood type selected. "
+              "Von-Neumann and Moore are valid for Node2D.");
   }
 }
 
 void Node2D::getNeighbors(
   NodePtr & node,
-  std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validityCheckerFunctor,
+  std::function<bool(const unsigned int &, smac_planner::Node2D * &)> & validityCheckerFunctor,
   NodeVector & neighbors)
 {
   // NOTE(stevemacenski): Irritatingly, the order here matters. If you start in free
@@ -119,10 +121,9 @@ void Node2D::getNeighbors(
   NodePtr neighbor;
   int node_i = node->getIndex();
 
-  for(unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
+  for (unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
     index = node_i + _neighbors_grid_offsets[i];
-    if (validityCheckerFunctor(index, neighbor))
-    {
+    if (validityCheckerFunctor(index, neighbor)) {
       neighbors.push_back(neighbor);
     }
   }

--- a/smac_planner/src/node_2d.cpp
+++ b/smac_planner/src/node_2d.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include "smac_planner/node_2d.hpp"
+
+namespace smac_planner
+{
+
+// defining static member for all instance to share
+std::vector<int> Node2D::_neighbors_grid_offsets;
+
+Node2D::Node2D(unsigned char & cost_in, const unsigned int index)
+: parent(nullptr),
+  _cell_cost(static_cast<float>(cost_in)),
+  _accumulated_cost(std::numeric_limits<float>::max()),
+  _index(index),
+  _was_visited(false),
+  _is_queued(false)
+{
+}
+
+Node2D::~Node2D()
+{
+  parent = nullptr;
+}
+
+void Node2D::reset(const unsigned char & cost, const unsigned int index)
+{
+  parent = nullptr;
+  _cell_cost = static_cast<float>(cost);
+  _accumulated_cost = std::numeric_limits<float>::max();
+  _index = index;
+  _was_visited = false;
+  _is_queued = false;
+}
+
+bool Node2D::isNodeValid(const bool & traverse_unknown) {
+  // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
+  // the regular grid (e.g. your node is on the edge of the costmap and i+1
+  // goes to the other side). This check would add compute time and my assertion is
+  // that if you do wrap around, the heuristic will be so high it'll be added far
+  // in the queue that it will never be called if a valid path exists.
+  // This is intentionally un-included to increase speed, but be aware. If this causes
+  // trouble, please file a ticket and we can address it then.
+
+  // occupied node
+  auto & cost = this->getCost();
+  if (cost == OCCUPIED || cost == INSCRIBED) {
+    return false;
+  }
+
+  // unknown node
+  if (cost == UNKNOWN && ! traverse_unknown) {
+    return false;
+  }
+
+  return true;
+}
+
+float Node2D::getHeuristicCost(
+  const Coordinates & node_coords,
+  const Coordinates & goal_coordinates)
+{
+  return hypotf(
+    goal_coordinates.x - node_coords.x,
+    goal_coordinates.y - node_coords.y);
+}
+
+void Node2D::initNeighborhood(
+  const unsigned int & x_size_uint,
+  const MotionModel & neighborhood)
+{
+  int x_size = static_cast<int>(x_size_uint);
+  switch (neighborhood) {
+    case MotionModel::UNKNOWN:
+      throw std::runtime_error("Unknown neighborhood type selected.");
+    case MotionModel::VON_NEUMANN:
+      _neighbors_grid_offsets = {-1, +1, -x_size, +x_size};
+      break;
+    case MotionModel::MOORE:
+      _neighbors_grid_offsets = {-1, +1, -x_size, +x_size, -x_size - 1,
+                                 -x_size + 1, +x_size - 1, +x_size + 1};
+      break;
+    default:
+      throw std::runtime_error("Invalid neighborhood type selected. "
+        "Von-Neumann and Moore are valid for Node2D.");
+  }
+}
+
+void Node2D::getNeighbors(
+  NodePtr & node,
+  std::function<bool(const unsigned int&, smac_planner::Node2D*&)> & validity_checker,
+  NodeVector & neighbors)
+{
+  // NOTE(stevemacenski): Irritatingly, the order here matters. If you start in free
+  // space and then expand 8-connected, the first set of neighbors will be all cost
+  // _neutral_cost. Then its expansion will all be 2 * _neutral_cost but now multiple
+  // nodes are touching that node so the last cell to update the back pointer wins.
+  // Thusly, the ordering ends with the cardinal directions for both sets such that
+  // behavior is consistent in large free spaces between them.
+  // 100  50   0
+  // 100  50  50
+  // 100 100 100   where lower-middle '100' is visited with same cost by both bottom '50' nodes
+  // Therefore, it is valuable to have some low-potential across the entire map
+  // rather than a small inflation around the obstacles
+  int index;
+  NodePtr neighbor;
+  int node_i = node->getIndex();
+
+  for(unsigned int i = 0; i != _neighbors_grid_offsets.size(); ++i) {
+    index = node_i + _neighbors_grid_offsets[i];
+    if (index > 0 && validity_checker(index, neighbor))
+    {
+      neighbors.push_back(neighbor);
+    }
+  }
+}
+
+}  // namespace smac_planner

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -117,35 +117,35 @@ void MotionTable::initReedsShepp(
 // Allows a differential drive robot to move in all the basic ways
 // its base can allow: forward and back, spin in place, rotate while moving
 // This isn't a 'pure' implementation, but in the right theme
-void MotionTable::initBalkcomMason(
-  unsigned int & size_x_in,
-  unsigned int & num_angle_quantization_in)
-{
-  size_x = size_x_in;
-  num_angle_quantization = num_angle_quantization_in;
-  num_angle_quantization_float = static_cast<float>(num_angle_quantization);
+// void MotionTable::initBalkcomMason(
+//   unsigned int & size_x_in,
+//   unsigned int & num_angle_quantization_in)
+// {
+//   size_x = size_x_in;
+//   num_angle_quantization = num_angle_quantization_in;
+//   num_angle_quantization_float = static_cast<float>(num_angle_quantization);
 
-  bin_size =
-    2.0f * static_cast<float>(M_PI) / static_cast<float>(num_angle_quantization);
+//   bin_size =
+//     2.0f * static_cast<float>(M_PI) / static_cast<float>(num_angle_quantization);
 
-  // square root of two arc length used to ensure leaving current cell
-  const float sqrt_2 = sqrt(2.0);
+//   // square root of two arc length used to ensure leaving current cell
+//   const float sqrt_2 = sqrt(2.0);
 
-  // if we move sqrt(2) and an angle at the same time, there's a Y deflection
-  const float delta_y = sqrt_2 * sin(bin_size);
-  const float delta_x = sqrt_2 * cos(bin_size);
+//   // if we move sqrt(2) and an angle at the same time, there's a Y deflection
+//   const float delta_y = sqrt_2 * sin(bin_size);
+//   const float delta_x = sqrt_2 * cos(bin_size);
 
-  projections.clear();
-  projections.reserve(8);
-  projections.emplace_back(sqrt_2, 0.0, 0.0);  // Forward
-  projections.emplace_back(-sqrt_2, 0.0, 0.0);  // Backward
-  projections.emplace_back(0.0, 0.0, 1);  // Spin left
-  projections.emplace_back(0.0, 0.0, -1);  // Spin right
-  projections.emplace_back(delta_x, delta_y, 1);  // Spin left + Forward
-  projections.emplace_back(-delta_x, delta_y, -1);  // Spin left + Backward
-  projections.emplace_back(delta_x, -delta_y, -1);  // Spin right + Forward
-  projections.emplace_back(-sqrt_2, -delta_y, 1);  // Spin right + Backward
-}
+//   projections.clear();
+//   projections.reserve(8);
+//   projections.emplace_back(sqrt_2, 0.0, 0.0);  // Forward
+//   projections.emplace_back(-sqrt_2, 0.0, 0.0);  // Backward
+//   projections.emplace_back(0.0, 0.0, 1);  // Spin left
+//   projections.emplace_back(0.0, 0.0, -1);  // Spin right
+//   projections.emplace_back(delta_x, delta_y, 1);  // Spin left + Forward
+//   projections.emplace_back(-delta_x, delta_y, -1);  // Spin left + Backward
+//   projections.emplace_back(delta_x, -delta_y, -1);  // Spin right + Forward
+//   projections.emplace_back(-sqrt_2, -delta_y, 1);  // Spin right + Backward
+// }
 
 MotionPoses MotionTable::getProjections(NodeSE2 * & node)
 {
@@ -252,9 +252,9 @@ void NodeSE2::initMotionModel(
     case MotionModel::REEDS_SHEPP:
       _motion_model.initReedsShepp(size_x, num_angle_quantization, min_turning_radius);
       break;
-    case MotionModel::BALKCOM_MASON:
-      _motion_model.initBalkcomMason(size_x, num_angle_quantization);
-      break;
+    // case MotionModel::BALKCOM_MASON:
+    //   _motion_model.initBalkcomMason(size_x, num_angle_quantization);
+    //   break;
     default:
       throw std::runtime_error("Invalid motion model for SE2 node. Please select between"
         " Dubin (Ackermann forward only),"

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -66,18 +66,20 @@ void MotionTable::initDubin(
   float delta_x = min_turning_radius * sin(angle);
   // Using that same right triangle, we can see that the complement
   // to delta Y is R * cos (angle). If we subtract R, we get the actual value
-  float delta_y = (min_turning_radius * cos(angle)) - min_turning_radius;
+  float delta_y = min_turning_radius - (min_turning_radius * cos(angle));
 
   projections.clear();
   projections.reserve(3);
-  projections.emplace_back(sqrt_2, 0.0, 0.0);  // Forward
-  projections.emplace_back(delta_x, delta_y, angle);  // Left
-  projections.emplace_back(delta_x, -delta_y, -angle);  // Right
+  projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
+  projections.emplace_back(delta_x, delta_y, increments);  // Left
+  projections.emplace_back(delta_x, -delta_y, -increments);  // Right
 }
 
 // http://planning.cs.uiuc.edu/node822.html
 // Same as Dubin model but now reverse is valid
 // See notes in Dubin for explanation
+// TODO update reeds shepp and balkcom mason based on Dubin outcome 
+// TODO make sure operator+ handles backwards OK
 void MotionTable::initReedsShepp(
   unsigned int & size_x_in,
   unsigned int & num_angle_quantization_in,
@@ -101,10 +103,10 @@ void MotionTable::initReedsShepp(
 
   projections.clear();
   projections.reserve(6);
-  projections.emplace_back(sqrt_2, 0.0, 0.0);  // Forward
+  projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
   projections.emplace_back(delta_x, delta_y, angle);  // Forward + Left
   projections.emplace_back(delta_x, -delta_y, -angle);  // Forward + Right
-  projections.emplace_back(-sqrt_2, 0.0, 0.0);  // Backward
+  projections.emplace_back(-hypotf(delta_x, delta_y), 0.0, 0.0);  // Backward
   projections.emplace_back(-delta_x, delta_y, angle);  // Backward + Left
   projections.emplace_back(-delta_x, -delta_y, -angle);  // Backward + Right
 }
@@ -185,8 +187,6 @@ bool NodeSE2::isNodeValid(const bool & traverse_unknown) {
   // in the queue that it will never be called if a valid path exists.
   // This is intentionally un-included to increase speed, but be aware. If this causes
   // trouble, please file a ticket and we can address it then.
-
-  // TODO SE2 collision checking
 
   float & cost = this->getCost();
 

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include "smac_planner/node_se2.hpp"
+
+namespace smac_planner
+{
+
+// defining static member for all instance to share
+MotionTable NodeSE2::_motion_model;
+
+void MotionTable::initDublin(
+  unsigned int & size_x_in,
+  unsigned int & angle_quantization_in) //TODO
+{
+  size_x = size_x_in;
+  angle_quantization = angle_quantization_in;
+  projections.clear();
+  projections.reserve(3);
+  projections.emplace_back(0, 0.7068582, 0.0415893);
+  projections.emplace_back(-0.0415893, 0.705224, 0.1178097);
+  projections.emplace_back(0.0415893, 0.705224, -0.1178097);
+}
+
+void MotionTable::initReedsShepp(
+  unsigned int & size_x_in,
+  unsigned int & angle_quantization_in) //TODO
+{
+  size_x = size_x_in;
+  angle_quantization = angle_quantization_in;
+  projections.clear();
+  projections.reserve(3);
+  projections.emplace_back(0, 0.7068582, 0.0415893);
+  projections.emplace_back(-0.0415893, 0.705224, 0.1178097);
+  projections.emplace_back(0.0415893, 0.705224, -0.1178097);
+}
+
+void MotionTable::initBalkcomMason(
+  unsigned int & size_x_in,
+  unsigned int & angle_quantization_in) //TODO
+{
+  size_x = size_x_in;
+  angle_quantization = angle_quantization_in;
+  projections.clear();
+  projections.reserve(3);
+  projections.emplace_back(0, 0.7068582, 0.0415893);
+  projections.emplace_back(-0.0415893, 0.705224, 0.1178097);
+  projections.emplace_back(0.0415893, 0.705224, -0.1178097);
+}
+
+Poses MotionTable::getProjections(NodeSE2 * & node)
+{
+  Poses projections;
+  for (uint i = 0; i != projections.size(); i++) {
+    projections.push_back(getProjection(node, i));
+  }
+
+  return projections;
+}
+
+Pose MotionTable::getProjection(NodeSE2 * & node, const unsigned int & motion_index)
+{
+  return node->pose + projections[motion_index];
+}
+
+NodeSE2::NodeSE2(unsigned char & cost_in, const unsigned int index)
+: parent(nullptr),
+  _cell_cost(static_cast<float>(cost_in)),
+  _accumulated_cost(std::numeric_limits<float>::max()),
+  _index(index),
+  _was_visited(false),
+  _is_queued(false)
+{
+}
+
+NodeSE2::~NodeSE2()
+{
+  parent = nullptr;
+}
+
+void NodeSE2::reset(const unsigned char & cost, const unsigned int index)
+{
+  parent = nullptr;
+  _cell_cost = static_cast<float>(cost);
+  _accumulated_cost = std::numeric_limits<float>::max();
+  _index = index;
+  _was_visited = false;
+  _is_queued = false;
+}
+
+bool NodeSE2::isNodeValid(const bool & traverse_unknown) {
+  // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
+  // the regular grid (e.g. your node is on the edge of the costmap and i+1
+  // goes to the other side). This check would add compute time and my assertion is
+  // that if you do wrap around, the heuristic will be so high it'll be added far
+  // in the queue that it will never be called if a valid path exists.
+  // This is intentionally un-included to increase speed, but be aware. If this causes
+  // trouble, please file a ticket and we can address it then.
+
+  // occupied node
+  auto & cost = this->getCost();
+  if (cost == OCCUPIED || cost == INSCRIBED) {
+    return false;
+  }
+
+  // unknown node
+  if (cost == UNKNOWN && ! traverse_unknown) {
+    return false;
+  }
+
+  return true;
+}
+
+float NodeSE2::getHeuristicCost(
+  const Coordinates & node_coords,
+  const Coordinates & goal_coordinates)
+{
+  return hypotf(
+    goal_coordinates.x - node_coords.x,
+    goal_coordinates.y - node_coords.y);
+}
+
+void NodeSE2::initMotionModel(
+  const MotionModel & motion_model,
+  unsigned int & size_x,
+  unsigned int & angle_quantization)
+{
+  // find the motion model selected
+  switch(motion_model) {
+    case MotionModel::DUBLIN:
+      _motion_model.initDublin(size_x, angle_quantization);
+      break;
+    case MotionModel::REEDS_SHEPP:
+      _motion_model.initReedsShepp(size_x, angle_quantization);
+      break;
+    case MotionModel::BALKCOM_MASON:
+      _motion_model.initBalkcomMason(size_x, angle_quantization);
+      break;
+    default:
+      throw std::runtime_error("Invalid motion model for SE2 node. Please select between"
+        " Dublin (Ackermann forward only),"
+        " Reeds-Shepp (Ackermann forward and back),"
+        " or Balkcom-Mason (Differential drive and omnidirectional) models.");
+  }
+}
+
+void NodeSE2::getNeighbors(
+  NodePtr & node,
+  std::function<bool(const unsigned int&, smac_planner::NodeSE2*&)> & validity_checker,
+  NodeVector & neighbors)
+{
+  int index;
+  NodePtr neighbor;
+  Poses projections = _motion_model.getProjections(node);
+
+  for(unsigned int i = 0; i != projections.size(); ++i) {
+    index = NodeSE2::getIndex(
+      projections[i]._x, projections[i]._y, projections[i]._theta,
+      _motion_model.size_x, _motion_model.angle_quantization);
+    if (validity_checker(index, neighbor))
+    {
+      neighbor->setPose(projections[i]);
+      neighbors.push_back(neighbor);
+    }
+  }
+}
+
+}  // namespace smac_planner

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -75,9 +75,6 @@ void MotionTable::initDubin(
   projections.emplace_back(sqrt_2, 0.0, 0.0);  // Forward
   projections.emplace_back(delta_x, delta_y, angle);  // Left
   projections.emplace_back(delta_x, -delta_y, -angle);  // Right
-
-  float l = 2 * min_turning_radius * sin(angle / 2);
-  std::cout << "L = " << l << std::endl;
 }
 
 // http://planning.cs.uiuc.edu/node822.html

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -41,10 +41,10 @@ void MotionTable::initDubin(
 
   // angle must meet 3 requirements:
   // 1) be increment of quantized bin size
-  // 2) chord length must be greater than sqrt(2) to leave current cell 
+  // 2) chord length must be greater than sqrt(2) to leave current cell
   // 3) maximum curvature must be respected, represented by minimum turning angle
   // Thusly:
-  // On circle of radius minimum turning angle, we need select motion primatives 
+  // On circle of radius minimum turning angle, we need select motion primatives
   // with chord length > sqrt(2) and be an increment of our bin size
   //
   // chord >= sqrt(2) >= 2 * R * sin (angle / 2); where angle / N = quantized bin size
@@ -176,7 +176,7 @@ MotionPose MotionTable::getProjection(NodeSE2 * & node, const unsigned int & mot
   while (new_heading < 0.0) {
     new_heading += num_angle_quantization_float;
   }
-  
+
   return MotionPose(delta_x + node->pose.x, delta_y + node->pose.y, new_heading);
 }
 
@@ -205,7 +205,8 @@ void NodeSE2::reset(const unsigned char & cost, const unsigned int index)
   _is_queued = false;
 }
 
-bool NodeSE2::isNodeValid(const bool & traverse_unknown) {
+bool NodeSE2::isNodeValid(const bool & traverse_unknown)
+{
   // NOTE(stevemacenski): Right now, we do not check if the node has wrapped around
   // the regular grid (e.g. your node is on the edge of the costmap and i+1
   // goes to the other side). This check would add compute time and my assertion is
@@ -245,7 +246,7 @@ void NodeSE2::initMotionModel(
   float min_turning_radius)
 {
   // find the motion model selected
-  switch(motion_model) {
+  switch (motion_model) {
     case MotionModel::DUBIN:
       _motion_model.initDubin(size_x, num_angle_quantization, min_turning_radius);
       break;
@@ -256,23 +257,24 @@ void NodeSE2::initMotionModel(
     //   _motion_model.initBalkcomMason(size_x, num_angle_quantization);
     //   break;
     default:
-      throw std::runtime_error("Invalid motion model for SE2 node. Please select between"
-        " Dubin (Ackermann forward only),"
-        " Reeds-Shepp (Ackermann forward and back),"
-        " or Balkcom-Mason (Differential drive and omnidirectional) models.");
+      throw std::runtime_error(
+              "Invalid motion model for SE2 node. Please select between"
+              " Dubin (Ackermann forward only),"
+              " Reeds-Shepp (Ackermann forward and back),"
+              " or Balkcom-Mason (Differential drive and omnidirectional) models.");
   }
 }
 
 void NodeSE2::getNeighbors(
   NodePtr & node,
-  std::function<bool(const unsigned int&, smac_planner::NodeSE2*&)> & validityCheckerFunctor,
+  std::function<bool(const unsigned int &, smac_planner::NodeSE2 * &)> & validityCheckerFunctor,
   NodeVector & neighbors)
 {
   unsigned int index;
   NodePtr neighbor = nullptr;
   const MotionPoses motion_projections = _motion_model.getProjections(node);
 
-  for(unsigned int i = 0; i != motion_projections.size(); i++) {
+  for (unsigned int i = 0; i != motion_projections.size(); i++) {
     index = NodeSE2::getIndex(
       static_cast<unsigned int>(motion_projections[i]._x),
       static_cast<unsigned int>(motion_projections[i]._y),

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -280,7 +280,7 @@ void NodeSE2::getNeighbors(
       static_cast<unsigned int>(motion_projections[i]._y),
       static_cast<unsigned int>(motion_projections[i]._theta),
       _motion_model.size_x, _motion_model.num_angle_quantization);
-    if (validityCheckerFunctor(index, neighbor)) {
+    if (validityCheckerFunctor(index, neighbor) && !neighbor->wasVisited()) {
       neighbor->setPose(
         Coordinates(
           motion_projections[i]._x,

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -49,17 +49,19 @@ void MotionTable::initDubin(
   //
   // chord >= sqrt(2) >= 2 * R * sin (angle / 2); where angle / N = quantized bin size
   // Thusly: angle <= 2.0 * asin(sqrt(2) / (2 * R))
-  float angle = 2.0 * asin(sqrt_2 / (2 * min_turning_radius));
+  float angle = 2.0 * asin(sqrt(2.0) / (2 * min_turning_radius));
   // Now make sure angle is an increment of the quantized bin size
   // And since its based on the minimum chord, we need to make sure its always larger
-  const float bin_size =
+  bin_size =
     2.0f * static_cast<float>(M_PI) / static_cast<float>(num_angle_quantization);
+  float increments;
   if (angle < bin_size) {
+    increments = 1.0f;
     angle = bin_size;
-  } else if (angle > bin_size) {
-    const int increments = ceil(angle / bin_size);
-    angle = bin_size * increments;
   }
+
+  // Search dimensions not promised to be clean multiples of quantization
+  increments = angle / bin_size;
 
   // find deflections
   // If we make a right triangle out of the chord in circle of radius
@@ -86,30 +88,31 @@ void MotionTable::initReedsShepp(
   unsigned int & num_angle_quantization_in,
   float & min_turning_radius)
 {
-  size_x = size_x_in;
-  num_angle_quantization = num_angle_quantization_in;
+  // size_x = size_x_in;
+  // num_angle_quantization = num_angle_quantization_in;
+  // num_angle_quantization_float = static_cast<float>(num_angle_quantization);
 
-  const float sqrt_2 = sqrt(2.0);
-  float angle = 2.0 * asin(sqrt_2 / (2 * min_turning_radius));
-  const float bin_size =
-    2.0f * static_cast<float>(M_PI) / static_cast<float>(num_angle_quantization);
-  if (angle < bin_size) {
-    angle = bin_size;
-  } else if (angle > bin_size) {
-    const int increments = ceil(angle / bin_size);
-    angle = bin_size * increments;
-  }
-  float delta_x = min_turning_radius * sin(angle);
-  float delta_y = (min_turning_radius * cos(angle)) - min_turning_radius;
+  // const float sqrt_2 = sqrt(2.0);
+  // float angle = 2.0 * asin(sqrt_2 / (2 * min_turning_radius));
+  // bin_size =
+  //   2.0f * static_cast<float>(M_PI) / static_cast<float>(num_angle_quantization);
+  // if (angle < bin_size) {
+  //   angle = bin_size;
+  // } else if (angle > bin_size) {
+  //   const int increments = ceil(angle / bin_size);
+  //   angle = bin_size * increments;
+  // }
+  // float delta_x = min_turning_radius * sin(angle);
+  // float delta_y = (min_turning_radius * cos(angle)) - min_turning_radius;
 
-  projections.clear();
-  projections.reserve(6);
-  projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
-  projections.emplace_back(delta_x, delta_y, angle);  // Forward + Left
-  projections.emplace_back(delta_x, -delta_y, -angle);  // Forward + Right
-  projections.emplace_back(-hypotf(delta_x, delta_y), 0.0, 0.0);  // Backward
-  projections.emplace_back(-delta_x, delta_y, angle);  // Backward + Left
-  projections.emplace_back(-delta_x, -delta_y, -angle);  // Backward + Right
+  // projections.clear();
+  // projections.reserve(6);
+  // projections.emplace_back(hypotf(delta_x, delta_y), 0.0, 0.0);  // Forward
+  // projections.emplace_back(delta_x, delta_y, angle);  // Forward + Left
+  // projections.emplace_back(delta_x, -delta_y, -angle);  // Forward + Right
+  // projections.emplace_back(-hypotf(delta_x, delta_y), 0.0, 0.0);  // Backward
+  // projections.emplace_back(-delta_x, delta_y, angle);  // Backward + Left
+  // projections.emplace_back(-delta_x, -delta_y, -angle);  // Backward + Right
 }
 
 // http://planning.cs.uiuc.edu/node823.html

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -183,7 +183,7 @@ void SmacPlanner::configure(
     _upsampling_ratio = 2;
   }
 
-  _a_star = std::make_unique<AStarAlgorithm<Node>>(neighborhood);
+  _a_star = std::make_unique<AStarAlgorithm<Node2D>>(neighborhood);
   _a_star->initialize(
     travel_cost_scale,
     allow_unknown,
@@ -277,7 +277,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
 
   // Set Costmap
   unsigned char * char_costmap = costmap->getCharMap();
-  _a_star->setCosts(
+  _a_star->createGraph(
     costmap->getSizeInCellsX(),
     costmap->getSizeInCellsY(),
     char_costmap);

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -430,7 +430,7 @@ void SmacPlanner::removeHook(std::vector<Eigen::Vector2d> & path)
   }
 }
 
-Eigen::Vector2d getWorldCoords(
+Eigen::Vector2d SmacPlanner::getWorldCoords(
   const float & mx, const float & my, const nav2_costmap_2d::Costmap2D * costmap)
 {
   float world_x = 

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -155,7 +155,7 @@ void SmacPlanner::configure(
   if (motion_model == MotionModel::UNKNOWN) {
     RCLCPP_WARN(_node->get_logger(),
       "Unable to get MotionModel search type. Given '%s', "
-      "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP, BALKCOM_MASON.",
+      "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
       motion_model_for_search.c_str());
   }
 

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -307,7 +307,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
   pose.pose.orientation.w = 1.0;
 
   // Compute plan
-  IndexPath path;
+  NodeSE2::CoordinateVector path;
   int num_iterations = 0;
   std::string error;
   try {
@@ -345,9 +345,12 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
       continue;
     }
 
-    path_world.push_back(getWorldCoords(path[i].first, path[i].second, costmap));
+    path_world.push_back(getWorldCoords(path[i].x, path[i].y, costmap));
     pose.pose.position.x = path_world.back().x();
     pose.pose.position.y = path_world.back().y();
+    tf2::Quaternion q;
+    q.setEuler(0.0, 0.0, path[i].theta * _angle_bin_size);  // theta is in continuous bin coordinates
+    pose.pose.orientation = tf2::toMsg(q);
     plan.poses.push_back(pose);
   }
 
@@ -391,6 +394,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
       pose.pose.position.x = path_world[i][0];
       pose.pose.position.y = path_world[i][1];
       plan.poses[i] = pose;
+      // TODO orientation from tangent
     }
     _smoothed_plan_publisher->publish(plan);
   }
@@ -412,6 +416,7 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
     pose.pose.position.x = path_world[i][0];
     pose.pose.position.y = path_world[i][1];
     plan.poses[i] = pose;
+    // TODO orientation from tangent
   }
 
   return plan;

--- a/smac_planner/src/smac_planner.cpp
+++ b/smac_planner/src/smac_planner.cpp
@@ -113,6 +113,7 @@ void SmacPlanner::configure(
   std::string neighborhood_for_search;
 
   // General planner params
+  //TODO STEVE number of quantized bins angle
   nav2_util::declare_parameter_if_not_declared(
     _node, name + ".tolerance", rclcpp::ParameterValue(0.125));
   _tolerance = static_cast<float>(_node->get_parameter(name + ".tolerance").as_double());
@@ -280,18 +281,18 @@ nav_msgs::msg::Path SmacPlanner::createPlan(
   _a_star->createGraph(
     costmap->getSizeInCellsX(),
     costmap->getSizeInCellsY(),
+    1, //TODO STEVE number of quanitized states, for SE2
     char_costmap);
 
   // Set starting point
   unsigned int mx, my, index;
   costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my);
-  index = costmap->getIndex(mx, my);
-  _a_star->setStart(index);
+  _a_star->setStart(mx, my, 0);//TODO STEVE angle bin, in bin coords NOT global coords, for SE2
 
   // Set goal point
   costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my);
   index = costmap->getIndex(mx, my);
-  _a_star->setGoal(index);
+  _a_star->setGoal(mx, my, 0);//TODO STEVE angle bin, in bin coords NOT global coords, for SE2
 
   // Setup message
   nav_msgs::msg::Path plan;

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -54,7 +54,6 @@ void SmacPlanner2D::configure(
   bool allow_unknown;
   int max_iterations;
   int max_on_approach_iterations;
-  int angle_quantizations;
   float travel_cost_scale;
   bool smooth_path;
   bool upsample_path;

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -227,14 +227,13 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
     char_costmap);
 
   // Set starting point
-  unsigned int mx, my, index;
+  unsigned int mx, my;
   costmap->worldToMap(start.pose.position.x, start.pose.position.y, mx, my);
   double orientation = tf2::getYaw(start.pose.orientation);
   _a_star->setStart(mx, my, 0);
 
   // Set goal point
   costmap->worldToMap(goal.pose.position.x, goal.pose.position.y, mx, my);
-  index = costmap->getIndex(mx, my);
   orientation = tf2::getYaw(start.pose.orientation);
   _a_star->setGoal(mx, my, 0);
 
@@ -281,8 +280,8 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   // We're going to downsample by 4x to give terms room to move.
   const int downsample_ratio = 4;
   std::vector<Eigen::Vector2d> path_world;
-  path_world.reserve(path.size() / downsample_ratio);
-  plan.poses.reserve(path.size() / downsample_ratio);
+  path_world.reserve(_smoother ? path.size() / downsample_ratio : path.size());
+  plan.poses.reserve(_smoother ? path.size() / downsample_ratio : path.size());
 
   for (int i = path.size() - 1; i >= 0; --i) {
     if (_smoother && i % downsample_ratio != 0) {

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -250,7 +250,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   pose.pose.orientation.w = 1.0;
 
   // Compute plan
-  IndexPath path;
+  Node2D::CoordinateVector path;
   int num_iterations = 0;
   std::string error;
   try {
@@ -288,7 +288,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
       continue;
     }
 
-    path_world.push_back(getWorldCoords(path[i].first, path[i].second, costmap));
+    path_world.push_back(getWorldCoords(path[i].x, path[i].y, costmap));
     pose.pose.position.x = path_world.back().x();
     pose.pose.position.y = path_world.back().y();
     plan.poses.push_back(pose);

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -64,10 +64,10 @@ void SmacPlanner2D::configure(
     _node, name + ".tolerance", rclcpp::ParameterValue(0.125));
   _tolerance = static_cast<float>(_node->get_parameter(name + ".tolerance").as_double());
   nav2_util::declare_parameter_if_not_declared(
-          _node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
+    _node, name + ".downsample_costmap", rclcpp::ParameterValue(true));
   _node->get_parameter(name + ".downsample_costmap", _downsample_costmap);
   nav2_util::declare_parameter_if_not_declared(
-          _node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
+    _node, name + ".downsampling_factor", rclcpp::ParameterValue(1));
   _node->get_parameter(name + ".downsampling_factor", _downsampling_factor);
 
   nav2_util::declare_parameter_if_not_declared(
@@ -97,20 +97,23 @@ void SmacPlanner2D::configure(
   _node->get_parameter(name + ".motion_model_for_search", motion_model_for_search);
   MotionModel motion_model = fromString(motion_model_for_search);
   if (motion_model == MotionModel::UNKNOWN) {
-    RCLCPP_WARN(_node->get_logger(),
+    RCLCPP_WARN(
+      _node->get_logger(),
       "Unable to get MotionModel search type. Given '%s', "
       "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
       motion_model_for_search.c_str());
   }
 
   if (max_on_approach_iterations <= 0) {
-    RCLCPP_INFO(_node->get_logger(), "On approach iteration selected as <= 0, "
+    RCLCPP_INFO(
+      _node->get_logger(), "On approach iteration selected as <= 0, "
       "disabling tolerance and on approach iterations.");
     max_on_approach_iterations = std::numeric_limits<int>::max();
   }
 
   if (max_iterations <= 0) {
-    RCLCPP_INFO(_node->get_logger(), "maximum iteration selected as <= 0, "
+    RCLCPP_INFO(
+      _node->get_logger(), "maximum iteration selected as <= 0, "
       "disabling maximum iterations.");
     max_iterations = std::numeric_limits<int>::max();
   }
@@ -121,13 +124,14 @@ void SmacPlanner2D::configure(
   }
 
   if (_upsampling_ratio != 2 && _upsampling_ratio != 4) {
-    RCLCPP_WARN(_node->get_logger(),
+    RCLCPP_WARN(
+      _node->get_logger(),
       "Upsample ratio set to %i, only 2 and 4 are valid. Defaulting to 2.", _upsampling_ratio);
     _upsampling_ratio = 2;
   }
-  std::cout << "hi"<< std::endl;
+  std::cout << "hi" << std::endl;
   _a_star = std::make_unique<AStarAlgorithm<Node2D>>(motion_model, 0.0f);
-  std::cout << "hi2"<< std::endl;
+  std::cout << "hi2" << std::endl;
   _a_star->initialize(
     travel_cost_scale,
     allow_unknown,
@@ -254,7 +258,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   std::string error;
   try {
     if (!_a_star->createPath(
-      path, num_iterations, _tolerance / static_cast<float>(costmap->getResolution())))
+        path, num_iterations, _tolerance / static_cast<float>(costmap->getResolution())))
     {
       if (num_iterations < _a_star->getMaxIterations()) {
         error = std::string("no valid path found");
@@ -301,9 +305,9 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   if (!_smoother) {
 #ifdef BENCHMARK_TESTING
     steady_clock::time_point b = steady_clock::now();
-    duration<double> time_span = duration_cast<duration<double> >(b-a);
+    duration<double> time_span = duration_cast<duration<double>>(b - a);
     cout << "It took " << time_span.count() * 1000 <<
-      " milliseconds with " << num_iterations << " iterations." <<  endl;
+      " milliseconds with " << num_iterations << " iterations." << endl;
 #endif
     return plan;
   }
@@ -317,7 +321,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
   MinimalCostmap mcmap(char_costmap, costmap->getSizeInCellsX(),
     costmap->getSizeInCellsY(), costmap->getOriginX(), costmap->getOriginY(),
     costmap->getResolution());
-  if (!_smoother->smooth(path_world, & mcmap, _smoother_params)) {
+  if (!_smoother->smooth(path_world, &mcmap, _smoother_params)) {
     RCLCPP_WARN(
       _node->get_logger(),
       "%s: failed to smooth plan, Ceres could not find a usable solution to optimize.",
@@ -339,8 +343,7 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 
   // Upsample path
   if (_upsampler) {
-    if(!_upsampler->upsample(path_world, _smoother_params, _upsampling_ratio))
-    {
+    if (!_upsampler->upsample(path_world, _smoother_params, _upsampling_ratio)) {
       RCLCPP_WARN(
         _node->get_logger(),
         "%s: failed to upsample plan, Ceres could not find a usable solution to optimize.",
@@ -375,7 +378,7 @@ void SmacPlanner2D::removeHook(std::vector<Eigen::Vector2d> & path)
 Eigen::Vector2d SmacPlanner2D::getWorldCoords(
   const float & mx, const float & my, const nav2_costmap_2d::Costmap2D * costmap)
 {
-  float world_x = 
+  float world_x =
     static_cast<float>(costmap->getOriginX()) + (mx + 0.5) * costmap->getResolution();
   float world_y =
     static_cast<float>(costmap->getOriginY()) + (my + 0.5) * costmap->getResolution();

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -99,7 +99,7 @@ void SmacPlanner2D::configure(
   if (motion_model == MotionModel::UNKNOWN) {
     RCLCPP_WARN(_node->get_logger(),
       "Unable to get MotionModel search type. Given '%s', "
-      "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP, BALKCOM_MASON.",
+      "valid options are MOORE, VON_NEUMANN, DUBIN, REEDS_SHEPP.",
       motion_model_for_search.c_str());
   }
 


### PR DESCRIPTION
Finishes #5 #30. 

- Adds SE2 node
- Adds 2D planner server and 2D template 
- removes balkcom mason, decided against it for now
- some linting
- removed some debug artifacts

Next tasks
- SE2 collision checking #25 
- Heuristics for expansion, travel costs, weights for turning and reversing. #32 #7
- Reeds-Sheep optimization inversely proportional to distance from goal. #6 