### PR TITLE
Add extensive unit testing

### DIFF
--- a/smac_planner/CMakeLists.txt
+++ b/smac_planner/CMakeLists.txt
@@ -113,6 +113,8 @@ install(DIRECTORY include/
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)

--- a/smac_planner/include/smac_planner/collision_checker.hpp
+++ b/smac_planner/include/smac_planner/collision_checker.hpp
@@ -22,7 +22,7 @@ namespace smac_planner
 {
 
 class GridCollisionChecker
-: public nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+  : public nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
 {
 public:
   GridCollisionChecker(

--- a/smac_planner/include/smac_planner/collision_checker.hpp
+++ b/smac_planner/include/smac_planner/collision_checker.hpp
@@ -13,6 +13,7 @@
 // limitations under the License. Reserved.
 
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
+#include "smac_planner/constants.hpp"
 
 #ifndef SMAC_PLANNER__COLLISION_CHECKER_HPP_
 #define SMAC_PLANNER__COLLISION_CHECKER_HPP_

--- a/smac_planner/include/smac_planner/collision_checker.hpp
+++ b/smac_planner/include/smac_planner/collision_checker.hpp
@@ -20,7 +20,8 @@
 namespace smac_planner
 {
 
-class GridCollisionChecker : public nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
+class GridCollisionChecker
+: public nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *>
 {
 public:
   GridCollisionChecker(

--- a/smac_planner/include/smac_planner/constants.hpp
+++ b/smac_planner/include/smac_planner/constants.hpp
@@ -15,6 +15,8 @@
 #ifndef SMAC_PLANNER__CONSTANTS_HPP_
 #define SMAC_PLANNER__CONSTANTS_HPP_
 
+#include <string>
+
 namespace smac_planner
 {
 enum class MotionModel

--- a/smac_planner/include/smac_planner/costmap_downsampler.hpp
+++ b/smac_planner/include/smac_planner/costmap_downsampler.hpp
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
-#ifndef SMAC_PLANNER__DOWNSAMPLER_HPP_
-#define SMAC_PLANNER__DOWNSAMPLER_HPP_
+#ifndef SMAC_PLANNER__COSTMAP_DOWNSAMPLER_HPP_
+#define SMAC_PLANNER__COSTMAP_DOWNSAMPLER_HPP_
 
 #include <algorithm>
+#include <string>
+#include <memory>
+
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 #include "smac_planner/constants.hpp"
 
@@ -109,4 +112,4 @@ private:
 
 }  // namespace smac_planner
 
-#endif // SMAC_PLANNER__DOWNSAMPLER_HPP_
+#endif  // SMAC_PLANNER__COSTMAP_DOWNSAMPLER_HPP_

--- a/smac_planner/include/smac_planner/node_2d.hpp
+++ b/smac_planner/include/smac_planner/node_2d.hpp
@@ -214,6 +214,7 @@ public:
 
   Node2D * parent;
   static double neutral_cost;
+  static std::vector<int> _neighbors_grid_offsets;
 
 private:
   float _cell_cost;
@@ -221,7 +222,6 @@ private:
   unsigned int _index;
   bool _was_visited;
   bool _is_queued;
-  static std::vector<int> _neighbors_grid_offsets;
 };
 
 }  // namespace smac_planner

--- a/smac_planner/include/smac_planner/node_basic.hpp
+++ b/smac_planner/include/smac_planner/node_basic.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
-#ifndef SMAC_PLANNER__NODE_3D_HPP_
-#define SMAC_PLANNER__NODE_3D_HPP_
+#ifndef SMAC_PLANNER__NODE_BASIC_HPP_
+#define SMAC_PLANNER__NODE_BASIC_HPP_
 
 #include <math.h>
 #include <vector>
@@ -25,7 +25,7 @@
 #include <utility>
 #include <limits>
 
-#include <ompl/base/StateSpace.h>
+#include "ompl/base/StateSpace.h"
 
 #include "smac_planner/constants.hpp"
 #include "smac_planner/node_se2.hpp"
@@ -78,4 +78,4 @@ template class NodeBasic<NodeSE2>;
 
 }  // namespace smac_planner
 
-#endif  // SMAC_PLANNER__NODE_3D_HPP_
+#endif  // SMAC_PLANNER__NODE_BASIC_HPP_

--- a/smac_planner/include/smac_planner/node_basic.hpp
+++ b/smac_planner/include/smac_planner/node_basic.hpp
@@ -29,6 +29,7 @@
 
 #include "smac_planner/constants.hpp"
 #include "smac_planner/node_se2.hpp"
+#include "smac_planner/node_2d.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/collision_checker.hpp"
 

--- a/smac_planner/include/smac_planner/node_basic.hpp
+++ b/smac_planner/include/smac_planner/node_basic.hpp
@@ -49,7 +49,8 @@ public:
    * @param index The index of this node for self-reference
    */
   explicit NodeBasic(const unsigned int index)
-  : _index(index)
+  : _index(index),
+    graph_node_ptr(nullptr)
   {}
 
   /**

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <limits>
 
-#include <ompl/base/StateSpace.h>
+#include "ompl/base/StateSpace.h"
 
 #include "smac_planner/constants.hpp"
 #include "smac_planner/types.hpp"

--- a/smac_planner/include/smac_planner/node_se2.hpp
+++ b/smac_planner/include/smac_planner/node_se2.hpp
@@ -299,6 +299,7 @@ public:
   NodeSE2 * parent;
   Coordinates pose;
   static double neutral_cost;
+  static MotionTable _motion_model;
 
 private:
   float _cell_cost;
@@ -307,7 +308,6 @@ private:
   bool _was_visited;
   bool _is_queued;
   unsigned int _motion_primitive_index;
-  static MotionTable _motion_model;
   static std::vector<unsigned int> _wavefront_heuristic;
 };
 

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
+#include <omp.h>
+
 #include <cmath>
 #include <stdexcept>
 #include <memory>
@@ -19,11 +21,11 @@
 #include <limits>
 #include <type_traits>
 #include <chrono>
-#include <omp.h>
 #include <thread>
+#include <utility>
 
 #include "smac_planner/a_star.hpp"
-using namespace std::chrono;
+using namespace std::chrono;  // NOLINT
 
 namespace smac_planner
 {
@@ -253,7 +255,6 @@ bool AStarAlgorithm<NodeT>::createPath(
     };
 
   while (iterations < getMaxIterations() && !_queue.empty()) {
-
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
 

--- a/smac_planner/src/a_star.cpp
+++ b/smac_planner/src/a_star.cpp
@@ -200,7 +200,9 @@ bool AStarAlgorithm<NodeT>::areInputsValid()
   }
 
   // Check if ending point is valid
-  if (getToleranceHeuristic() < 0.001 && !_goal->isNodeValid(_traverse_unknown, _collision_checker)) {
+  if (getToleranceHeuristic() < 0.001 &&
+    !_goal->isNodeValid(_traverse_unknown, _collision_checker))
+  {
     throw std::runtime_error("Failed to compute path, goal is occupied with no tolerance.");
   }
 
@@ -370,7 +372,7 @@ typename AStarAlgorithm<NodeT>::NodePtr AStarAlgorithm<NodeT>::getNextNode()
   return node.graph_node_ptr;
 }
 
-template <>
+template<>
 typename AStarAlgorithm<NodeSE2>::NodePtr AStarAlgorithm<NodeSE2>::getNextNode()
 {
   NodeBasic<NodeSE2> node = _queue.top().second;

--- a/smac_planner/src/costmap_downsampler.cpp
+++ b/smac_planner/src/costmap_downsampler.cpp
@@ -15,6 +15,10 @@
 
 #include "smac_planner/costmap_downsampler.hpp"
 
+#include <string>
+#include <memory>
+#include <algorithm>
+
 namespace smac_planner
 {
 

--- a/smac_planner/src/node_2d.cpp
+++ b/smac_planner/src/node_2d.cpp
@@ -14,6 +14,9 @@
 
 #include "smac_planner/node_2d.hpp"
 
+#include <vector>
+#include <limits>
+
 namespace smac_planner
 {
 

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -271,7 +271,8 @@ float NodeSE2::getHeuristicCost(
 
   const float motion_heuristic = _motion_model.state_space->distance(from(), to());
 
-  const unsigned int & wavefront_idx = static_cast<unsigned int>(node_coords.y) * _motion_model.size_x + static_cast<unsigned int>(node_coords.x);
+  const unsigned int & wavefront_idx = static_cast<unsigned int>(node_coords.y) *
+    _motion_model.size_x + static_cast<unsigned int>(node_coords.x);
   const unsigned int & wavefront_value = _wavefront_heuristic[wavefront_idx];
 
   // if lethal or didn't visit, use the motion heuristic instead.
@@ -337,7 +338,7 @@ void NodeSE2::computeWavefrontHeuristic(
 
   std::queue<unsigned int> q;
   q.emplace(goal_index);
-  
+
   unsigned int idx = goal_index;
   _wavefront_heuristic[idx] = 2;
 
@@ -361,8 +362,8 @@ void NodeSE2::computeWavefrontHeuristic(
 
       // if neighbor is unvisited and non-lethal, set N and add to queue
       if (new_idx > 0 && new_idx < size_x * size_y &&
-          _wavefront_heuristic[new_idx] == 0 &&
-          static_cast<float>(costmap->getCost(idx)) < INSCRIBED)
+        _wavefront_heuristic[new_idx] == 0 &&
+        static_cast<float>(costmap->getCost(idx)) < INSCRIBED)
       {
         my = new_idx / size_x;
         mx = new_idx - (my * size_x);

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -239,7 +239,7 @@ float NodeSE2::getTraversalCost(const NodePtr & child)
   float travel_cost = 0.0;
   float travel_cost_raw = NodeSE2::neutral_cost + _motion_model.cost_penalty * normalized_cost;
 
-  if (getMotionPrimitiveIndex() == 0 || getMotionPrimitiveIndex() == 3) {
+  if (child->getMotionPrimitiveIndex() == 0 || child->getMotionPrimitiveIndex() == 3) {
     // straight motion, no additional costs to be applied
     travel_cost = travel_cost_raw;
   } else {

--- a/smac_planner/src/node_se2.cpp
+++ b/smac_planner/src/node_se2.cpp
@@ -14,14 +14,19 @@
 
 #include <math.h>
 #include <chrono>
+#include <vector>
+#include <memory>
+#include <algorithm>
+#include <queue>
+#include <limits>
 
-#include <ompl/base/ScopedState.h>
-#include <ompl/base/spaces/DubinsStateSpace.h>
-#include <ompl/base/spaces/ReedsSheppStateSpace.h>
+#include "ompl/base/ScopedState.h"
+#include "ompl/base/spaces/DubinsStateSpace.h"
+#include "ompl/base/spaces/ReedsSheppStateSpace.h"
 
 #include "smac_planner/node_se2.hpp"
 
-using namespace std::chrono;
+using namespace std::chrono;  // NOLINT
 
 namespace smac_planner
 {

--- a/smac_planner/src/smac_planner_2d.cpp
+++ b/smac_planner/src/smac_planner_2d.cpp
@@ -15,14 +15,16 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <limits>
+#include <algorithm>
+
 #include "smac_planner/smac_planner_2d.hpp"
 
 #define BENCHMARK_TESTING
 
 namespace smac_planner
 {
-using namespace std::chrono;
-using namespace std;
+using namespace std::chrono;  // NOLINT
 
 SmacPlanner2D::SmacPlanner2D()
 : _a_star(nullptr),
@@ -133,8 +135,8 @@ void SmacPlanner2D::configure(
 
   if (smooth_path) {
     _smoother = std::make_unique<Smoother>();
-    _optimizer_params.get(_node.get(), name);  // Get optimizer params TODO per-run with time left over
-    _smoother_params.get(_node.get(), name);  // Get weights
+    _optimizer_params.get(_node.get(), name);
+    _smoother_params.get(_node.get(), name);
     _smoother->initialize(_optimizer_params);
 
     if (upsample_path && _upsampling_ratio > 0) {
@@ -294,8 +296,8 @@ nav_msgs::msg::Path SmacPlanner2D::createPlan(
 #ifdef BENCHMARK_TESTING
     steady_clock::time_point b = steady_clock::now();
     duration<double> time_span = duration_cast<duration<double>>(b - a);
-    cout << "It took " << time_span.count() * 1000 <<
-      " milliseconds with " << num_iterations << " iterations." << endl;
+    std::cout << "It took " << time_span.count() * 1000 <<
+      " milliseconds with " << num_iterations << " iterations." << std::endl;
 #endif
     return plan;
   }

--- a/smac_planner/test/CMakeLists.txt
+++ b/smac_planner/test/CMakeLists.txt
@@ -31,10 +31,18 @@ target_link_libraries(test_nodese2
   ${library_name}
 )
 
-
-
-
 # Test NodeBasic
+ament_add_gtest(test_nodebasic
+  test_nodese2.cpp
+)
+ament_target_dependencies(test_nodebasic
+  ${dependencies}
+)
+target_link_libraries(test_nodebasic
+  ${library_name}
+)
+
+
 
 
 # Test collision checker

--- a/smac_planner/test/CMakeLists.txt
+++ b/smac_planner/test/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(test_nodese2
 
 # Test NodeBasic
 ament_add_gtest(test_nodebasic
-  test_nodese2.cpp
+  test_nodebasic.cpp
 )
 ament_target_dependencies(test_nodebasic
   ${dependencies}
@@ -42,10 +42,22 @@ target_link_libraries(test_nodebasic
   ${library_name}
 )
 
-
-
-
 # Test collision checker
+ament_add_gtest(test_collision_checker
+  test_collision_checker.cpp
+)
+ament_target_dependencies(test_collision_checker
+  ${dependencies}
+)
+target_link_libraries(test_collision_checker
+  ${library_name}
+)
+
+
+
+
+
+
 
 # A*
 

--- a/smac_planner/test/CMakeLists.txt
+++ b/smac_planner/test/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Test costmap downsampler
+ament_add_gtest(test_costmap_downsampler
+  test_costmap_downsampler.cpp
+)
+ament_target_dependencies(test_costmap_downsampler
+  ${dependencies}
+)
+target_link_libraries(test_costmap_downsampler
+  ${library_name}
+)
+
+# Test Node2D
+ament_add_gtest(test_node2d
+  test_node2d.cpp
+)
+ament_target_dependencies(test_node2d
+  ${dependencies}
+)
+target_link_libraries(test_node2d
+  ${library_name}
+)
+
+# Test NodeSE2
+ament_add_gtest(test_nodese2
+  test_nodese2.cpp
+)
+ament_target_dependencies(test_nodese2
+  ${dependencies}
+)
+target_link_libraries(test_nodese2
+  ${library_name}
+)
+
+
+
+
+# Test NodeBasic
+
+
+# Test collision checker
+
+# A*
+
+# Test smoother (?)
+
+# Test upsampler (?)
+
+# Test SMAC SE2 : Create instance, give it known costmap, plan
+
+# Test SMAC 2D : Create instance, give it known costmap, plan
+
+# create planning server

--- a/smac_planner/test/test_collision_checker.cpp
+++ b/smac_planner/test/test_collision_checker.cpp
@@ -132,7 +132,9 @@ TEST(collision_footprint, test_footprint_at_pose_with_movement)
 
 TEST(collision_footprint, test_point_and_line_cost)
 {
-  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.10000, 0, 0.0, 0.0);
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(
+    100, 100, 0.10000, 0, 0.0,
+    0.0);
 
   costmap_->setCost(62, 50, 254);
   costmap_->setCost(39, 60, 254);

--- a/smac_planner/test/test_collision_checker.cpp
+++ b/smac_planner/test/test_collision_checker.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) 2020 Shivang Patel
+// Copyright (c) 2020 Samsung Research
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "smac_planner/collision_checker.hpp"
+
+using namespace nav2_costmap_2d;  // NOLINT
+
+TEST(collision_footprint, test_basic)
+{
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 0);
+
+  geometry_msgs::msg::Point p1;
+  p1.x = -0.5;
+  p1.y = 0.0;
+  geometry_msgs::msg::Point p2;
+  p2.x = 0.0;
+  p2.y = 0.5;
+  geometry_msgs::msg::Point p3;
+  p3.x = 0.5;
+  p3.y = 0.0;
+  geometry_msgs::msg::Point p4;
+  p4.x = 0.0;
+  p4.y = -0.5;
+
+  nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
+
+  smac_planner::GridCollisionChecker collision_checker(costmap_);
+  collision_checker.setFootprint(footprint, false /*use footprint*/);
+  collision_checker.inCollision(5.0, 5.0, 0.0, false);
+  float cost = collision_checker.getCost();
+  EXPECT_NEAR(cost, 0.0, 0.001);
+  delete costmap_;
+}
+
+TEST(collision_footprint, test_point_cost)
+{
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 0);
+
+  smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_costmap_2d::Footprint footprint;
+  collision_checker.setFootprint(footprint, true /*radius / pointcose*/);
+
+  collision_checker.inCollision(5.0, 5.0, 0.0, false);
+  float cost = collision_checker.getCost();
+  EXPECT_NEAR(cost, 0.0, 0.001);
+  delete costmap_;
+}
+
+TEST(collision_footprint, test_world_to_map)
+{
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 0);
+
+  smac_planner::GridCollisionChecker collision_checker(costmap_);
+  nav2_costmap_2d::Footprint footprint;
+  collision_checker.setFootprint(footprint, true /*radius / point cost*/);
+
+  unsigned int x, y;
+
+  collision_checker.worldToMap(1.0, 1.0, x, y);
+
+  collision_checker.inCollision(x, y, 0.0, false);
+  float cost = collision_checker.getCost();
+
+  EXPECT_NEAR(cost, 0.0, 0.001);
+
+  costmap_->setCost(50, 50, 200);
+  collision_checker.worldToMap(5.0, 5.0, x, y);
+
+  collision_checker.inCollision(x, y, 0.0, false);
+  EXPECT_NEAR(collision_checker.getCost(), 200.0, 0.001);
+  delete costmap_;
+}
+
+TEST(collision_footprint, test_footprint_at_pose_with_movement)
+{
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.1, 0, 0, 254);
+
+  for (unsigned int i = 40; i <= 60; ++i) {
+    for (unsigned int j = 40; j <= 60; ++j) {
+      costmap_->setCost(i, j, 0);
+    }
+  }
+
+  geometry_msgs::msg::Point p1;
+  p1.x = -1.0;
+  p1.y = 1.0;
+  geometry_msgs::msg::Point p2;
+  p2.x = 1.0;
+  p2.y = 1.0;
+  geometry_msgs::msg::Point p3;
+  p3.x = 1.0;
+  p3.y = -1.0;
+  geometry_msgs::msg::Point p4;
+  p4.x = -1.0;
+  p4.y = -1.0;
+
+  nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
+
+  smac_planner::GridCollisionChecker collision_checker(costmap_);
+  collision_checker.setFootprint(footprint, false /*use footprint*/);
+
+  collision_checker.inCollision(50, 50, 0.0, false);
+  float cost = collision_checker.getCost();
+  EXPECT_NEAR(cost, 0.0, 0.001);
+
+  collision_checker.inCollision(50, 49, 0.0, false);
+  float up_value = collision_checker.getCost();
+  EXPECT_NEAR(up_value, 254.0, 0.001);
+
+  collision_checker.inCollision(50, 52, 0.0, false);
+  float down_value = collision_checker.getCost();
+  EXPECT_NEAR(down_value, 254.0, 0.001);
+  delete costmap_;
+}
+
+TEST(collision_footprint, test_point_and_line_cost)
+{
+  nav2_costmap_2d::Costmap2D * costmap_ = new nav2_costmap_2d::Costmap2D(100, 100, 0.10000, 0, 0.0, 0.0);
+
+  costmap_->setCost(62, 50, 254);
+  costmap_->setCost(39, 60, 254);
+
+  geometry_msgs::msg::Point p1;
+  p1.x = -1.0;
+  p1.y = 1.0;
+  geometry_msgs::msg::Point p2;
+  p2.x = 1.0;
+  p2.y = 1.0;
+  geometry_msgs::msg::Point p3;
+  p3.x = 1.0;
+  p3.y = -1.0;
+  geometry_msgs::msg::Point p4;
+  p4.x = -1.0;
+  p4.y = -1.0;
+
+  nav2_costmap_2d::Footprint footprint = {p1, p2, p3, p4};
+
+  smac_planner::GridCollisionChecker collision_checker(costmap_);
+  collision_checker.setFootprint(footprint, false /*use footprint*/);
+
+  collision_checker.inCollision(50, 50, 0.0, false);
+  float value = collision_checker.getCost();
+  EXPECT_NEAR(value, 0.0, 0.001);
+
+  collision_checker.inCollision(49, 50, 0.0, false);
+  float left_value = collision_checker.getCost();
+  EXPECT_NEAR(left_value, 254.0, 0.001);
+
+  collision_checker.inCollision(52, 50, 0.0, false);
+  float right_value = collision_checker.getCost();
+  EXPECT_NEAR(right_value, 254.0, 0.001);
+  delete costmap_;
+}

--- a/smac_planner/test/test_costmap_downsampler.cpp
+++ b/smac_planner/test/test_costmap_downsampler.cpp
@@ -45,7 +45,7 @@ TEST(CostmapDownsampler, costmap_downsample_test)
 
   // downsample it
   downsampler.initialize("map", "unused_topic", &costmapA, 2);
-  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);  
+  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);
 
   // validate it
   EXPECT_EQ(downsampledCostmapA->getCost(0, 0), 100);
@@ -58,7 +58,7 @@ TEST(CostmapDownsampler, costmap_downsample_test)
 
   // downsample it
   downsampler.initialize("map", "unused_topic", &costmapB, 4);
-  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);  
+  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);
 
   // validate size
   EXPECT_EQ(downsampledCostmapB->getSizeInCellsX(), 1u);

--- a/smac_planner/test/test_costmap_downsampler.cpp
+++ b/smac_planner/test/test_costmap_downsampler.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "smac_planner/costmap_downsampler.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(CostmapDownsampler, costmap_downsample_test)
+{
+  nav2_util::LifecycleNode::SharedPtr node = std::make_shared<nav2_util::LifecycleNode>(
+    "CostmapDownsamplerTest");
+  smac_planner::CostmapDownsampler downsampler(node);
+  auto map_sub = nav2_costmap_2d::CostmapSubscriber(node, "unused_topic");
+
+  // create basic costmap
+  nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
+  costmapA.setCost(0, 0, 100);
+  costmapA.setCost(5, 5, 50);
+
+  // downsample it
+  downsampler.initialize("map", "unused_topic", &costmapA, 2);
+  nav2_costmap_2d::Costmap2D * downsampledCostmapA = downsampler.downsample(2);  
+
+  // validate it
+  EXPECT_EQ(downsampledCostmapA->getCost(0, 0), 100);
+  EXPECT_EQ(downsampledCostmapA->getCost(2, 2), 50);
+  EXPECT_EQ(downsampledCostmapA->getSizeInCellsX(), 5u);
+  EXPECT_EQ(downsampledCostmapA->getSizeInCellsY(), 5u);
+
+  // give it another costmap of another size
+  nav2_costmap_2d::Costmap2D costmapB(4, 4, 0.05, 0.0, 0.0, 0);
+
+  // downsample it
+  downsampler.initialize("map", "unused_topic", &costmapB, 4);
+  nav2_costmap_2d::Costmap2D * downsampledCostmapB = downsampler.downsample(4);  
+
+  // validate size
+  EXPECT_EQ(downsampledCostmapB->getSizeInCellsX(), 1u);
+  EXPECT_EQ(downsampledCostmapB->getSizeInCellsY(), 1u);
+
+}

--- a/smac_planner/test/test_node2d.cpp
+++ b/smac_planner/test/test_node2d.cpp
@@ -118,7 +118,7 @@ TEST(Node2DTest, test_node_2d_neighbors)
   nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
   smac_planner::GridCollisionChecker checker(&costmapA);
   unsigned char cost = static_cast<unsigned int>(1);
-  smac_planner::Node2D * node = new smac_planner::Node2D(cost,1);
+  smac_planner::Node2D * node = new smac_planner::Node2D(cost, 1);
   std::function<bool(const unsigned int &, smac_planner::Node2D * &)> neighborGetter =
     [&, this](const unsigned int & index, smac_planner::Node2D * & neighbor_rtn) -> bool
     {

--- a/smac_planner/test/test_node2d.cpp
+++ b/smac_planner/test/test_node2d.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "smac_planner/node_2d.hpp"
+#include "smac_planner/collision_checker.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(Node2DTest, test_node_2d)
+{
+  nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
+  smac_planner::GridCollisionChecker checker(&costmapA);
+
+  // test construction
+  unsigned char cost = static_cast<unsigned char>(1);
+  smac_planner::Node2D testA(cost, 1);
+  smac_planner::Node2D testB(cost, 1);
+  EXPECT_EQ(testA.getCost(), 1.0f);
+
+  // test reset
+  testA.reset(10);
+  EXPECT_EQ(testA.getCost(), 10.0f);
+
+  // Check constants
+  EXPECT_EQ(testA.neutral_cost, 50.0f);
+
+  // check collision checking
+  EXPECT_EQ(testA.isNodeValid(false, checker), true);
+  testA.reset(254);
+  EXPECT_EQ(testA.isNodeValid(false, checker), false);
+  testA.reset(255);
+  EXPECT_EQ(testA.isNodeValid(true, checker), true);
+  EXPECT_EQ(testA.isNodeValid(false, checker), false);
+  testA.reset(10);
+
+  // check traversal cost computation
+  EXPECT_EQ(testB.getTraversalCost(&testA), 58.0f);
+
+  // check heuristic cost computation
+  smac_planner::Node2D::Coordinates A(0.0, 0.0);
+  smac_planner::Node2D::Coordinates B(10.0, 5.0);
+  EXPECT_NEAR(testB.getHeuristicCost(A, B), 559.016, 0.01);
+
+  // check operator== works on index
+  unsigned char costC = '2';
+  smac_planner::Node2D testC(costC, 1);
+  EXPECT_TRUE(testA == testC);
+
+  // check accumulated costs are set
+  testC.setAccumulatedCost(100);
+  EXPECT_EQ(testC.getAccumulatedCost(), 100.0f);
+
+  // check visiting state
+  EXPECT_EQ(testC.wasVisited(), false);
+  testC.queued();
+  EXPECT_EQ(testC.isQueued(), true);
+  testC.visited();
+  EXPECT_EQ(testC.wasVisited(), true);
+  EXPECT_EQ(testC.isQueued(), false);
+
+  // check index
+  EXPECT_EQ(testC.getIndex(), 1u);
+
+  // check static index functions
+  EXPECT_EQ(smac_planner::Node2D::getIndex(1u, 1u, 10u), 11u);
+  EXPECT_EQ(smac_planner::Node2D::getIndex(6u, 43u, 10u), 436u);
+  EXPECT_EQ(smac_planner::Node2D::getCoords(436u, 10u, 1u).x, 6u);
+  EXPECT_EQ(smac_planner::Node2D::getCoords(436u, 10u, 1u).y, 43u);
+}
+
+TEST(Node2DTest, test_node_2d_neighbors)
+{
+  // test neighborhood computation
+  smac_planner::Node2D::initNeighborhood(10u, smac_planner::MotionModel::VON_NEUMANN);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets.size(), 4u);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[0], -1);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[1], 1);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[2], -10);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[3], 10);
+
+  smac_planner::Node2D::initNeighborhood(100u, smac_planner::MotionModel::MOORE);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets.size(), 8u);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[0], -1);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[1], 1);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[2], -100);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[3], 100);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[4], -101);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[5], -99);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[6], 99);
+  EXPECT_EQ(smac_planner::Node2D::_neighbors_grid_offsets[7], 101);
+
+  nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
+  smac_planner::GridCollisionChecker checker(&costmapA);
+  unsigned char cost = static_cast<unsigned int>(1);
+  smac_planner::Node2D * node = new smac_planner::Node2D(cost,1);
+  std::function<bool(const unsigned int &, smac_planner::Node2D * &)> neighborGetter =
+    [&, this](const unsigned int & index, smac_planner::Node2D * & neighbor_rtn) -> bool
+    {
+      return true;
+    };
+
+  smac_planner::Node2D::NodeVector neighbors;
+  smac_planner::Node2D::getNeighbors(node, neighborGetter, checker, false, neighbors);
+  delete node;
+
+  // should be empty since totally invalid
+  EXPECT_EQ(neighbors.size(), 0u);
+}

--- a/smac_planner/test/test_nodebasic.cpp
+++ b/smac_planner/test/test_nodebasic.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <math.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "smac_planner/node_basic.hpp"
+#include "smac_planner/node_2d.hpp"
+#include "smac_planner/node_se2.hpp"
+#include "smac_planner/collision_checker.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(NodeBasicTest, test_node_basic)
+{
+  smac_planner::NodeBasic<NodeSE2> node(50);
+
+  EXPECT_EQ(node.getIndex(), 50u);
+  EXPECT_EQ(node.graph_node_ptr, nullptr);
+
+  smac_planner::NodeBasic<Node2D> node2(100);
+
+  EXPECT_EQ(node.getIndex(), 100u);
+  EXPECT_EQ(node.graph_node_ptr, nullptr);
+}

--- a/smac_planner/test/test_nodebasic.cpp
+++ b/smac_planner/test/test_nodebasic.cpp
@@ -37,13 +37,13 @@ RclCppFixture g_rclcppfixture;
 
 TEST(NodeBasicTest, test_node_basic)
 {
-  smac_planner::NodeBasic<NodeSE2> node(50);
+  smac_planner::NodeBasic<smac_planner::NodeSE2> node(50);
 
   EXPECT_EQ(node.getIndex(), 50u);
   EXPECT_EQ(node.graph_node_ptr, nullptr);
 
-  smac_planner::NodeBasic<Node2D> node2(100);
+  smac_planner::NodeBasic<smac_planner::Node2D> node2(100);
 
-  EXPECT_EQ(node.getIndex(), 100u);
-  EXPECT_EQ(node.graph_node_ptr, nullptr);
+  EXPECT_EQ(node2.getIndex(), 100u);
+  EXPECT_EQ(node2.graph_node_ptr, nullptr);
 }

--- a/smac_planner/test/test_nodese2.cpp
+++ b/smac_planner/test/test_nodese2.cpp
@@ -136,9 +136,6 @@ TEST(NodeSE2Test, test_node_se2)
 
 TEST(Node2DTest, test_node_2d_neighbors)
 {
-  smac_planner::NodeSE2 node(5);
-  (void)node;
-
   smac_planner::SearchInfo info;
   info.change_penalty = 1.2;
   info.non_straight_penalty = 1.4;
@@ -192,8 +189,20 @@ TEST(Node2DTest, test_node_2d_neighbors)
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._x, -1.39194, 0.01);
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._y, -0.25, 0.01);
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._theta, 4.07283, 0.01);
+
+  nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
+  smac_planner::GridCollisionChecker checker(&costmapA);
+  smac_planner::NodeSE2 * node = new smac_planner::NodeSE2(49);
+  std::function<bool(const unsigned int &, smac_planner::NodeSE2 * &)> neighborGetter =
+    [&, this](const unsigned int & index, smac_planner::NodeSE2 * & neighbor_rtn) -> bool
+    {
+      return true;
+    };
+
+  smac_planner::NodeSE2::NodeVector neighbors;
+  smac_planner::NodeSE2::getNeighbors(node, neighborGetter, checker, false, neighbors);
+  delete node;
+
+  // should be empty since totally invalid
+  EXPECT_EQ(neighbors.size(), 0u);
 }
-
-
-// TODO computeWavefrontHeuristic
-// getProjections / getneighbors

--- a/smac_planner/test/test_nodese2.cpp
+++ b/smac_planner/test/test_nodese2.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) 2020, Samsung Research America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License. Reserved.
+
+#include <math.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_subscriber.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "smac_planner/node_se2.hpp"
+#include "smac_planner/collision_checker.hpp"
+
+class RclCppFixture
+{
+public:
+  RclCppFixture() {rclcpp::init(0, nullptr);}
+  ~RclCppFixture() {rclcpp::shutdown();}
+};
+RclCppFixture g_rclcppfixture;
+
+TEST(NodeSE2Test, test_node_se2)
+{
+  smac_planner::SearchInfo info;
+  info.change_penalty = 1.2;
+  info.non_straight_penalty = 1.4;
+  info.reverse_penalty = 2.1;
+  info.minimum_turning_radius = 0.20;
+  unsigned int size_x = 10;
+  unsigned int size_y = 10;
+  unsigned int size_theta = 72;
+  smac_planner::NodeSE2::initMotionModel(
+    smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
+
+  nav2_costmap_2d::Costmap2D * costmapA = new nav2_costmap_2d::Costmap2D(
+    10, 10, 0.05, 0.0, 0.0, 0);
+  smac_planner::GridCollisionChecker checker(costmapA);
+
+  // test construction
+  smac_planner::NodeSE2 testA(49);
+  smac_planner::NodeSE2 testB(49);
+  EXPECT_TRUE(std::isnan(testA.getCost()));
+
+  // test node valid and cost
+  EXPECT_EQ(testA.isNodeValid(true, checker), true);
+  EXPECT_EQ(testA.isNodeValid(false, checker), true);
+  EXPECT_EQ(testA.getCost(), 0.0f);
+
+  // test reset
+  testA.reset();
+  EXPECT_TRUE(std::isnan(testA.getCost()));
+
+  // Check constants
+  EXPECT_EQ(testA.neutral_cost, sqrt(2));
+
+  // check collision checking
+  EXPECT_EQ(testA.isNodeValid(false, checker), true);
+
+  // check traversal cost computation
+  // simulated first node, should return neutral cost
+  EXPECT_NEAR(testB.getTraversalCost(&testA), sqrt(2), 0.01);
+  // now with straight motion, cost is 0, so will be sqrt(2) as well
+  testB.setMotionPrimitiveIndex(1);
+  testA.setMotionPrimitiveIndex(0);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), sqrt(2), 0.01);
+  // same direction as parent, testB
+  testA.setMotionPrimitiveIndex(1);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 1.9799f, 0.01);
+  // opposite direction as parent, testB
+  testA.setMotionPrimitiveIndex(2);
+  EXPECT_NEAR(testB.getTraversalCost(&testA), 3.67696f, 0.01);
+
+  // will throw because never collision checked testB
+  EXPECT_THROW(testA.getTraversalCost(&testB), std::runtime_error);
+
+  // check motion primitives
+  EXPECT_EQ(testA.getMotionPrimitiveIndex(), 2u);
+
+  // check heuristic cost computation
+  smac_planner::NodeSE2::computeWavefrontHeuristic(
+    costmapA,
+    static_cast<unsigned int>(10.0),
+    static_cast<unsigned int>(5.0),
+    0.0, 0.0);
+  smac_planner::NodeSE2::Coordinates A(0.0, 0.0, 4.2);
+  smac_planner::NodeSE2::Coordinates B(10.0, 5.0, 54.1);
+  EXPECT_NEAR(testB.getHeuristicCost(B, A), 16.723, 0.01);
+
+  // check operator== works on index
+  smac_planner::NodeSE2 testC(49);
+  EXPECT_TRUE(testA == testC);
+
+  // check accumulated costs are set
+  testC.setAccumulatedCost(100);
+  EXPECT_EQ(testC.getAccumulatedCost(), 100.0f);
+
+  // check visiting state
+  EXPECT_EQ(testC.wasVisited(), false);
+  testC.queued();
+  EXPECT_EQ(testC.isQueued(), true);
+  testC.visited();
+  EXPECT_EQ(testC.wasVisited(), true);
+  EXPECT_EQ(testC.isQueued(), false);
+
+  // check index
+  EXPECT_EQ(testC.getIndex(), 49u);
+
+  // check set pose and pose
+  testC.setPose(smac_planner::NodeSE2::Coordinates(10.0, 5.0, 4));
+  EXPECT_EQ(testC.pose.x, 10.0);
+  EXPECT_EQ(testC.pose.y, 5.0);
+  EXPECT_EQ(testC.pose.theta, 4);
+
+  // check static index functions
+  EXPECT_EQ(smac_planner::NodeSE2::getIndex(1u, 1u, 4u, 10u, 72u), 796u);
+  EXPECT_EQ(smac_planner::NodeSE2::getCoords(796u, 10u, 72u).x, 1u);
+  EXPECT_EQ(smac_planner::NodeSE2::getCoords(796u, 10u, 72u).y, 1u);
+  EXPECT_EQ(smac_planner::NodeSE2::getCoords(796u, 10u, 72u).theta, 4u);
+
+  delete costmapA;
+}
+
+TEST(Node2DTest, test_node_2d_neighbors)
+{
+  smac_planner::NodeSE2 node(5);
+  (void)node;
+
+  smac_planner::SearchInfo info;
+  info.change_penalty = 1.2;
+  info.non_straight_penalty = 1.4;
+  info.reverse_penalty = 2.1;
+  info.minimum_turning_radius = 4;  // 0.2 in grid coordinates
+  unsigned int size_x = 10;
+  unsigned int size_y = 10;
+  unsigned int size_theta = 72;
+  smac_planner::NodeSE2::initMotionModel(
+    smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
+
+
+  // test neighborhood computation
+  EXPECT_EQ(smac_planner::NodeSE2::_motion_model.projections.size(), 3u);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._x, 1.41421, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._y, 0, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._theta, 0, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._x, 1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._y, 0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._theta, 4.07283, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._x, 1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._y, -0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._theta, -4.07283, 0.01);
+
+  smac_planner::NodeSE2::initMotionModel(
+        smac_planner::MotionModel::REEDS_SHEPP, size_x, size_y, size_theta, info);
+
+  EXPECT_EQ(smac_planner::NodeSE2::_motion_model.projections.size(), 6u);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._x, 1.41421, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._y, 0, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._theta, 0, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._x, 1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._y, 0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[1]._theta, 4.07283, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._x, 1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._y, -0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._theta, -4.07283, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[3]._x, -1.41421, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[3]._y, 0, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[3]._theta, 0, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[4]._x, -1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[4]._y, 0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[4]._theta, -4.07283, 0.01);
+
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._x, -1.39194, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._y, -0.25, 0.01);
+  EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._theta, 4.07283, 0.01);
+}
+
+
+// TODO computeWavefrontHeuristic
+// getProjections / getneighbors

--- a/smac_planner/test/test_nodese2.cpp
+++ b/smac_planner/test/test_nodese2.cpp
@@ -141,8 +141,8 @@ TEST(Node2DTest, test_node_2d_neighbors)
   info.non_straight_penalty = 1.4;
   info.reverse_penalty = 2.1;
   info.minimum_turning_radius = 4;  // 0.2 in grid coordinates
-  unsigned int size_x = 10;
-  unsigned int size_y = 10;
+  unsigned int size_x = 100;
+  unsigned int size_y = 100;
   unsigned int size_theta = 72;
   smac_planner::NodeSE2::initMotionModel(
     smac_planner::MotionModel::DUBIN, size_x, size_y, size_theta, info);
@@ -190,13 +190,14 @@ TEST(Node2DTest, test_node_2d_neighbors)
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._y, -0.25, 0.01);
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[5]._theta, 4.07283, 0.01);
 
-  nav2_costmap_2d::Costmap2D costmapA(10, 10, 0.05, 0.0, 0.0, 0);
+  nav2_costmap_2d::Costmap2D costmapA(100, 100, 0.05, 0.0, 0.0, 0);
   smac_planner::GridCollisionChecker checker(&costmapA);
   smac_planner::NodeSE2 * node = new smac_planner::NodeSE2(49);
   std::function<bool(const unsigned int &, smac_planner::NodeSE2 * &)> neighborGetter =
     [&, this](const unsigned int & index, smac_planner::NodeSE2 * & neighbor_rtn) -> bool
     {
-      return true;
+      // because we don't return a real object
+      return false;
     };
 
   smac_planner::NodeSE2::NodeVector neighbors;

--- a/smac_planner/test/test_nodese2.cpp
+++ b/smac_planner/test/test_nodese2.cpp
@@ -163,7 +163,7 @@ TEST(Node2DTest, test_node_2d_neighbors)
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[2]._theta, -4.07283, 0.01);
 
   smac_planner::NodeSE2::initMotionModel(
-        smac_planner::MotionModel::REEDS_SHEPP, size_x, size_y, size_theta, info);
+    smac_planner::MotionModel::REEDS_SHEPP, size_x, size_y, size_theta, info);
 
   EXPECT_EQ(smac_planner::NodeSE2::_motion_model.projections.size(), 6u);
   EXPECT_NEAR(smac_planner::NodeSE2::_motion_model.projections[0]._x, 1.41421, 0.01);


### PR DESCRIPTION
- [x] downsampler
- [x] NodeSE2
- [x] Node2D
- [x] NodeBasic
- [ ] upsampler
- [ ] smoother
- [ ] A*
- [ ] SMAC
- [ ] SMAC2D
- [x] collision checker

https://github.com/SteveMacenski/navigation2/issues/9

Specifically note the change https://github.com/SteveMacenski/navigation2/pull/50/files#diff-6d91bf1f19e4f8503d65b04c8010c6ebR242 changing `if (child->getMotionPrimitiveIndex() == 0 || child->getMotionPrimitiveIndex() == 3) {` to use `child->` not the parent. Please verify that this is the correct interpretation. 